### PR TITLE
feat: implement simple LLM-based workflow using LangGraph

### DIFF
--- a/Agentic AI using LangGraph/1_bmi_workflow.ipynb
+++ b/Agentic AI using LangGraph/1_bmi_workflow.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 1,
    "id": "74d2cb2c",
    "metadata": {},
    "outputs": [],
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 2,
    "id": "63e0cf57",
    "metadata": {},
    "outputs": [],
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 3,
    "id": "58dd885d",
    "metadata": {},
    "outputs": [],
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 4,
    "id": "bbcfe3ff",
    "metadata": {},
    "outputs": [],
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 5,
    "id": "cca1b199",
    "metadata": {},
    "outputs": [],
@@ -109,17 +109,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 6,
    "id": "481ddf05",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<langgraph.graph.state.StateGraph at 0x22fe79fab60>"
+       "<langgraph.graph.state.StateGraph at 0x200c8ed7700>"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -147,17 +147,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 7,
    "id": "668e32ff",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<langgraph.graph.state.StateGraph at 0x22fe79fab60>"
+       "<langgraph.graph.state.StateGraph at 0x200c8ed7700>"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 8,
    "id": "f2a0d03e",
    "metadata": {},
    "outputs": [],
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 9,
    "id": "f86c6f15",
    "metadata": {},
    "outputs": [
@@ -230,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 10,
    "id": "ac75da20",
    "metadata": {},
    "outputs": [
@@ -241,7 +241,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/Agentic AI using LangGraph/2_simple_llm_workflow.ipynb
+++ b/Agentic AI using LangGraph/2_simple_llm_workflow.ipynb
@@ -1,0 +1,276 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3f2553b7",
+   "metadata": {},
+   "source": [
+    "# <center>Simple LLM Based Workflow</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e72ba3e6",
+   "metadata": {},
+   "source": [
+    "### Import modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "771b1475",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.graph import StateGraph, START, END\n",
+    "from langchain_google_genai import ChatGoogleGenerativeAI\n",
+    "from typing import TypedDict\n",
+    "from dotenv import load_dotenv\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "ca0e3e69",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Google API Key exists and begins AI\n"
+     ]
+    }
+   ],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "google_api_key = os.getenv('GOOGLE_API_KEY')\n",
+    "\n",
+    "if google_api_key:\n",
+    "    print(f\"Google API Key exists and begins {google_api_key[:2]}\")\n",
+    "else:\n",
+    "    print(\"Google API Key not set (and this is optional)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "4ce7cbdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize Gemini model\n",
+    "# Make sure you have GOOGLE_API_KEY in your .env file\n",
+    "model = ChatGoogleGenerativeAI(\n",
+    "    model=model_name,\n",
+    "    google_api_key=os.getenv(\"GOOGLE_API_KEY\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "ed205313",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LLMState(TypedDict):\n",
+    "    question: str\n",
+    "    answer: str\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "ad443a59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_name = \"gemini-2.5-flash-lite\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "1db5bc56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# response = model.chat.completions.create(model=model_name, messages=messages)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "84210cd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def llm_qa(state: LLMState) -> LLMState:\n",
+    "    question = state['question']\n",
+    "    \n",
+    "    # form a prompt\n",
+    "    prompt = f'Answer the following question {question}'\n",
+    "    \n",
+    "    # Ask that question to the LLM\n",
+    "    answer = model.invoke(prompt).content\n",
+    "    \n",
+    "    # update the answer in the state\n",
+    "    state['answer'] = answer\n",
+    "    \n",
+    "    return state"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40e48518",
+   "metadata": {},
+   "source": [
+    "### Create graph and Add node"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "d6ba9f37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = StateGraph(LLMState)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7e4caf0",
+   "metadata": {},
+   "source": [
+    "### Add nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "ec4ef283",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<langgraph.graph.state.StateGraph at 0x1fabc6999f0>"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "graph.add_node('llm_qa', llm_qa)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99f19dc0",
+   "metadata": {},
+   "source": [
+    "### Add edges"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "1dcfd33a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<langgraph.graph.state.StateGraph at 0x1fabc6999f0>"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# First Edge\n",
+    "graph.add_edge(START, 'llm_qa')\n",
+    "\n",
+    "#Second Edge\n",
+    "graph.add_edge('llm_qa', END)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28916a8e",
+   "metadata": {},
+   "source": [
+    "### Compile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "568782b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow = graph.compile()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d18185e1",
+   "metadata": {},
+   "source": [
+    "### Execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "4342b260",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'question': 'How far is moon from the earth?', 'answer': \"The distance between the Earth and the Moon isn't constant because the Moon's orbit around the Earth is elliptical, not a perfect circle.\\n\\nHowever, we can give you the **average distance**:\\n\\nThe average distance from the Earth to the Moon is approximately **384,400 kilometers (km)** or **238,900 miles**.\\n\\nHere's a little more detail:\\n\\n*   **Perigee:** The point in the Moon's orbit when it's closest to Earth. At perigee, the distance is about 363,300 km (225,700 miles).\\n*   **Apogee:** The point in the Moon's orbit when it's farthest from Earth. At apogee, the distance is about 405,500 km (251,900 miles).\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "initial_state = {'question': \"How far is moon from the earth?\"}\n",
+    "\n",
+    "final_state = workflow.invoke(initial_state)\n",
+    "\n",
+    "print(final_state)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "myenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ langchain
 langchain_openai
 dotenv
 ipykernel
+langchain_google_genai


### PR DESCRIPTION
- Set up a basic LangGraph chain to process user questions.
- Takes a user question as input and returns an LLM-generated answer.
- Demonstrates a simple LLM integration workflow using LangGraph.
- Useful for testing and prototyping LLM-based flows.