### PR TITLE
feat: add parallel essay evaluation workflow using LangGraph

### DIFF
--- a/Agentic AI using LangGraph/4_simple_parallel_workflow.ipynb
+++ b/Agentic AI using LangGraph/4_simple_parallel_workflow.ipynb
@@ -1,0 +1,246 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "66a58379",
+   "metadata": {},
+   "source": [
+    "# <center>Parallel Workflow</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbc5254e",
+   "metadata": {},
+   "source": [
+    "### Import module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "00dcb3a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.graph import StateGraph, START, END\n",
+    "from langchain_google_genai import ChatGoogleGenerativeAI\n",
+    "from typing import TypedDict\n",
+    "from dotenv import load_dotenv\n",
+    "import os\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cabec21",
+   "metadata": {},
+   "source": [
+    "### State define"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e14689b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BatsmanState(TypedDict):\n",
+    "\n",
+    "    runs: int\n",
+    "    balls: int\n",
+    "    fours: int\n",
+    "    sixes: int\n",
+    "\n",
+    "    sr: float\n",
+    "    bpb: float\n",
+    "    boundary_percent: float\n",
+    "    summary: str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "87baef18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculate_sr(state: BatsmanState):\n",
+    "\n",
+    "    sr = (state['runs']/state['balls'])*100\n",
+    "    \n",
+    "    return {'sr': sr}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9edba1bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculate_bpb(state: BatsmanState):\n",
+    "\n",
+    "    bpb = state['balls']/(state['fours'] + state['sixes'])\n",
+    "\n",
+    "    return {'bpb': bpb}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "03db5748",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculate_boundary_percent(state: BatsmanState):\n",
+    "\n",
+    "    boundary_percent = (((state['fours'] * 4) + (state['sixes'] * 6))/state['runs'])*100\n",
+    "\n",
+    "    return {'boundary_percent': boundary_percent}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6562a198",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def summary(state: BatsmanState):\n",
+    "\n",
+    "    summary = f\"\"\"\n",
+    "Strike Rate - {state['sr']} \\n\n",
+    "Balls per boundary - {state['bpb']} \\n\n",
+    "Boundary percent - {state['boundary_percent']}\n",
+    "\"\"\"\n",
+    "    \n",
+    "    return {'summary': summary}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64b0de2e",
+   "metadata": {},
+   "source": [
+    "### Define graph, add node, add edge, compile and execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "92a51bec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = StateGraph(BatsmanState)\n",
+    "\n",
+    "graph.add_node('calculate_sr', calculate_sr)\n",
+    "graph.add_node('calculate_bpb', calculate_bpb)\n",
+    "graph.add_node('calculate_boundary_percent', calculate_boundary_percent)\n",
+    "graph.add_node('summary', summary)\n",
+    "\n",
+    "# edges\n",
+    "\n",
+    "graph.add_edge(START, 'calculate_sr')\n",
+    "graph.add_edge(START, 'calculate_bpb')\n",
+    "graph.add_edge(START, 'calculate_boundary_percent')\n",
+    "\n",
+    "graph.add_edge('calculate_sr', 'summary')\n",
+    "graph.add_edge('calculate_bpb', 'summary')\n",
+    "graph.add_edge('calculate_boundary_percent', 'summary')\n",
+    "\n",
+    "graph.add_edge('summary', END)\n",
+    "\n",
+    "workflow = graph.compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8078a914",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk8AAAFNCAIAAACWhRyvAAAAAXNSR0IArs4c6QAAIABJREFUeJzt3XdYFNfeB/CzBXZZytJ7UQRUitJsYFREY68hiu21JdEkJprojSWaqDFVTVGjXizxGmMwltiS2EsUrCgIWOgiVXpZWLa+f0zu3A3SorvM7vD9PD4+22bmx+7OfPecmTnDUavVBAAAgNW4TBcAAACgc0g7AABgP6QdAACwH9IOAADYD2kHAADsh7QDAAD24zNdAAC8EJlUXZovlVQrJdUKlUItlxnAOUUCE66RgCuy4JlZ8O3cBEyXAx0C0g7AIEklyoe3a7JTJZUlcrEN39SCL7LgW1jzlUoDSDsOhzx9IpXUKI2NuY8fSjr7m3oGmHn6mzJdF7AZB2eXAxgWtZrEnygtftJg5yLo7G/q6mXCdEUvpKFOlZ0qycuoK8isDxtt6xVoxnRFwE5IOwBD8uBmzfkDxeGjbYMiLJmuRcuqyxXxJ0rlDaqh0xyFpjikALQMaQdgMC4fKTE25vYbbcN0ITpUViD7dWve8FlOht5mBX2DtAMwDBcOPLV1EfToL2a6kPbw69b8l8bb2TobM10IsAfSDsAAHPt3gae/aUB4h4g6yq9b8wPCxNiNB9qCznEAfXf1eKl7V1GHijpCyIS3XG6cKqt4Kme6EGAJpB2AXku/W8vncYIGse2YlLaYutTj4sGnTFcBLIG0A9Brlw4/DYywYroKZnA4pFN3UfyJMqYLATZA2gHorzsXK3z7WAhFHXc9DR5slXq9qqFOxXQhYPA67loEoP8e368LH23LdBUMG/iKXeLlSqarAIOHtAPQU9mpEiMhl3DadaHLli07duzYc0w4dOjQ/Px8HVRE3HxEKdeqdDFn6FCQdgB6KjtF0tmvvYeOvH///nNMVVhYWFFRoYNyCCHExIxnYc0vfizV0fyhg8D5dgB66siW/JFznHS00y4uLm7v3r2pqam2trY9e/Z85513bG1tQ0NDqWfNzMwuXbpUW1u7b9++a9euZWZm2traDhw48M033xQKhYSQyMjI11577cKFC3fv3t24cePixYupCQcOHLhx40atV3vvSpVcpgqJ7KBH64BWoG0HoI9kUlVJfoOOou7hw4cLFy7s1avXoUOHPvjgg7S0tNWrV1MRSAhZtWrVpUuXCCGxsbF79uyZMWPGt99+u3DhwrNnz8bExFBzMDIy+vXXX7t27fr999+Hh4d/++23hJBjx47pIuoIISJzXklegy7mDB0HrvgDoI8k1UozMU9HM09MTBQKhXPmzOFyuY6Ojr6+vhkZGc++bPr06ZGRkZ07d6buJiUlxcfHv/vuu4QQDocjFouXLFmiowobMRXzJVWK9lkWsBXSDkAfSaoVIgtdrZ6BgYFSqXTRokV9+vQZMGCAm5sb3YepycjI6Nq1ax9//HFaWppCoSCEWFtb08/6+vrqqLxnmVrwJNVIO3gh6MkE0EdqFTEW6qpt161bt02bNtnZ2W3evHnChAlvvfVWUlLSsy/bvHlzTEzMhAkTjh49evv27dmzZ2s+a2zcfkM28/gcvjE2VvBC8AUC0Ecic15VqUx38w8LC1u1atWJEydWr15dVVW1aNEiqvVGU6vVhw8fnjx58oQJExwdHQkhNTU1uqunZbWVCiPj9j0VA1gHaQegj0zFfN313SUkJMTHxxNC7OzsRo8evXjx4pqamsLCQs3XyOXy+vp6e3t76q5MJvvzzz91VE+rJNVKUzF2u8ALQdoB6COhiGvnIlQqdHKCUFJS0gcffHDkyJGKioqUlJTY2Fg7OzsnJyeBQGBvb3/9+vXbt29zudxOnTodP348Ly+vsrJy7dq1gYGB1dXVEonk2Rl26tSJEHL27NmUlBRdFNxQr7RzEepiztBxIO0A9JSJGTcruYloeXHTp0+fMGHChg0bhg4d+sYbb5iamsbExPD5fELInDlzbt26tXjx4vr6+s8++0woFEZFRY0fP753794LFiwQCoVDhgwpKChoNENXV9cxY8Zs37598+bNuij4UUKNU2ekHbwQnF0OoKfS7tTk3K97eboD04UwTCFX71iZ9eaXXZguBAwb2nYAeqqTr2l9jZLpKpiXl1bv37djXckWdAE7fgH0kUwmUxGVjYvx3UuVzV3KVaVSDR48uLnJjYyMOJwmjmP09PTcvXu3tuv9y549e/bs2dPkU2ZmZrW1tU0+5e/vv2XLlubmGXeiZOQcZ+3VCB0UejIB9EJRUVF6enpaWlpGRkZ6enpBQUFsbKybq/vWf2W8vdGruame3YVGqa2tNTMza/IpPp9PH2mpdTU1Nc2dqCCVSqkxNp9lbGxsa9v0hY0e3KzOz6wfMqWjd+fCi0PaATBAoVBoZltaWppIJPL29vbx8fH29vby8qKOcqQGRFYp1YHNNO9Y7+TOwsjJDibm2OcCLwppB9AeSkpK0tLS0tPTMzIy0tLScnNzqWzz8vKiblhYWDQ37e8/FHYNsejSo72v/sO4EzEFPV6y9Oguoi5FZGNj4+CARh48J6QdgPap1WrNbEtPT+fz+XS7zcfHx9PT8x/N8MfPHg+b4WjvJtBZyXrnQuxTS3uj4MF/XeXn5MmT27ZtMzIyCgoKCg4ODgoKcnV1ZbpGMCRIOwAtKC8vp1KNkpGRoZltPj4+lpYv1hWpJge/y+s3ysbV20RrReuxCweeenQ3fbY5m5eXd/fu3Tt37ty9e1cul1OxFxwcTHf8AjQHaQfwPKj9bZS0tDS1Wk3FG90/qYuFHt2a7xNi4dvHXBcz1xMqJTm6Lc87yDwgvJWzDoqLi6nYu3PnTk1NDZ18OnrzwdAh7QBaV1lZSR9UQrXhPD096Wzz9va2sbFpn0qu/16WnSoJG2Pr0U3UPktsTzfPlKffrY2IsnPu8s+asGVlZXSbr7i4OCQkJDAwMCQkpFu3bjorFgwM0g6gCdnZ2ZoHTMpkMjrYKFwuY0cJlhbI4k+WmpjynLuYdPYzFZnr6sJA7eZpbsOT9LpbZ8qDIqx6D7Nu6izBf6C6uppu8+Xk5ISEhFBtvoCAAK1VDAYIaQdAampqGh1U4urqqrnjTXcnqD23gsz6h7drslMl1g7GlnZGphZ8kQXPTMxX6GYgae3ickl1uUJSreAQzoNb1eZW/C49zHq+ZMnX9mV96uvrExISqOR7+PAh1dtJ5Z92FwT6D2kHHdHjx481s622tpY6lqRLly7UDWqIZINQnNtQmt8gqVZIqhUcDqe+VpuDjdXV1WVmZmq9VWQm5nG4HJEFz9zKyKWLSfs0T+VyOdXmS0hISExMDA4Opnf1GdDHDc8NaQfsJ5FI0jWkpaU5OjpqZht1tVJ4Vlpa2urVq/fv3890IdqXkJBAd3j6+vrSHZ7NDfgChg6/aICF8vLyNLOtsrKS2tnWrVu3sWPHent7CwQd6MQ1aFJISEhISAh1+969e3fu3ImNjV26dGnnzp3pDs/mRl8DQ4S2HRg8qVSqecBkWlqara0tPUaJt7e3i4sL0zUaKha37Zpz//59us3n6OhIt/msrKyYLg1eCNIODE9hYSF9KndaWlpJSYnmAZM+Pj4mJh3iFOx20AHTTlN6ejp9kIulpSXd5rOzs2O6NPjHkHag7+RyeaMDJs3MzKj9bdQBk25ubkzXyFodPO00ZWdn0we5CIVC+ggXZ2dcjcgwYL8d6J2nT59qjsKVl5dHHzA5ePBgHx8f7E2B9te5c+fOnTu/8sor1I7hhISEhISEmJgYtVpNxV5wcLC7uzvTZUKz0LYDhqlUKs1sS0tLEwgEmt2SGAKRQWjbtaqoqIhu89XV1dFtvi5dujBdGvwN2nbQ3kpLSzUv7ZaVlUVn24ABA7y9vcXiVgZIBNAfjo6OI0eOHDlyJPXdppLv0KFDZWVl9OUaMICZPkDbDnSu0bluXC5X89JuGMNXn6Ft99wqKyvpoTufPHlCt/n8/f2ZLq2DQtqBllVWVlKnAdAHlVCpRvdMWltbM10jtBXSTiskEgl9VkNaWhp9VkNgYCDTpXUgSDt4UVlZWZrZplAo6KYbdXQJ0wXC80PaaZ1MJrtz5w4VfklJSXTyBQUF8XgGP8C3PsN+O/hnqqurNS8OkJ6e7u7uTmVbdHS0t7c3TkUCaIGxsXHfvn379u1LHaJFJd+uXbvu3LkTEBBAd3hiuB+tQ9sOWkENoExnW11dnebFAby9vTGiLouhbdeeEhMT6Q5PLy8vetxqnHKjFdhOwd9QAyhrnhJADaDs5eU1ceJEb29vDKAMoCOBgYH0nrzU1NQ7d+4cOXJk1apVLi4udJvP0tKS6TINFdp2HV1eXp7mSCWVlZWa1yzFAModHNp2+uDRo0d0m8/a2pre1Wdra8t0aYYEadexNDmAsma2YQBl0IS00zdZWVn0QS4mJib00J3odGkVejJZrtEAyqWlpfT+tuHDh2MAZQDD4unp6enpGRUVRQjJzc29c+fOzZs3t2/fTl3DKDAwMCQkBCPHNgltO1ahB1CmYQBleBFo2xmKwsJC6prsCQkJUqmUavMFBQVhADMa2naGrbi4WDPb6AGUvby8IiMjMYAyQAfh5OQ0evTo0aNHE0JKSkqors6DBw/SA5gFBwd37dqV6TKZhLadIXl2AGWhUKg5TAkGUAbtQtvO0FVVVdH7+egBzEJCQvz8/Jgurb2hbafXNAdQTktLy87OxgDKANB2YrE4IiIiIiJCcwCz9evXp6WlBf9XBxnADG07/aJ5cQDNAZSphEMXPLQztO3Yih7A7M6dO/fu3aMafFSfJ1sHMEPaManJAZTpiwNgAGVgHNKuI1CpVNT1+ahT+gICAuhdfWw63RZp197S0tLOnDmDAZTBICDtOqCkpCR6V1+XLl2Cg4OnTZvGgjPZkXbtSqFQjB8/Pioqiso2FnyBgN3S09M3bdq0efNmpgsBZqSmpl64cCEpKWnnzp1M1/KicJRKu1KpVOXl5bNmzWK6EIA2UavVZWVlTFcBjPHz8xMKhVevXmW6EC3gMl0AAACAziHtAACA/ZB2AADAfkg7AABgP6QdAACwH9IOAADYD2kHAADsh7QDAAD2Q9oBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAf0g4AANgPaQcAAOyHq7m2hwULFmRnZ/P5fLVanZeX5+LiwuVy5XL577//znRpAE2Ijo6uq6sjhMjl8vLycgcHB0KIVCo9c+YM06VBO5k8ebJUKlWr1XK5vKyszMnJSa1WNzQ0nD59munSnhPadu1hxowZdXV1+fn5BQUFXC63sLAwPz+/qKiI6boAmjZ27NiioqKCgoKSkhKlUllQUFBQUGBhYcF0XdB+Jk6cWFhYSH0HVCoVtfky6O8A0q499OnTx9fXV/MRlUoVFhbGXEUALYmOjnZ3d9d8hMPhDBo0iLmKoL1NnjzZzc1N8xEOh/PSSy8xV9GLQtq1k+nTp4vFYvquhYXF7NmzGa0IoFlcLnf8+PE8Ho9+xM3NLTo6mtGioL1FRUVpfgfc3d0nTZrEaEUvBGnXTvr16+fj40PfDQoKCgkJYbQigJZER0e7uLhQtzkczpAhQ2xtbZkuCtpVdHQ03bzjcDgRERGOjo5MF/X8kHbtZ+bMmVTzztraetasWUyXA9ASPp//6quvUj/t3d3dX331VaYrgvbG4XCmTZsmEAgIIR4eHob+HUDatZ++fftSzbsePXr07NmT6XIAWjFp0iQXFxcOhxMZGWlnZ8d0OcCACRMmUN+BgQMHUofmGi5+q6+Q1qnKChrqahTtUg/LjR38Rt1Ti2Hh09Pv1jBdi+HjcEzNedaOAqGpYfxok9apSgsa6g1qVRoXOe/y5cu9fcca0DeWy+OKbfg2TgKOYXwvSHW5orxIJm9QMl1I08ZFzjt//nwfv3F6+x0QmfNtnFrfDrRyvt3Fg09z7tdZ2BiZiHgtvAyg/XF4HEmlvL5O1am76KXx+r5L6dz+4txHddaOAmOBgWyDDZaJBb8wq04g4gWEWfgEmzNdTkuqyxWXD5WUFTW4dzOV1upp2um/ulplbZWiU3fRoKiWeiBaSrvfdhc5eJh0DRU39wIAfZAaX1ld1vDydP3tZjm6vcCju5lXoAGfq2SILsQW+vY29w4yY7qQptVWKo79uyBisrO5Vet9bNCqB7eqyvLqR8xq9jiaZtPuzL5iWxcT72Csn2AA7l+vrKuSRUyyZ7qQJpzcVejR3aKTnynThXRE534qCBwo7qyXb/73izNmrPQylO5Wg/AooaqySDpkatM/fJt+p4tzG2RSNaIODIVvX8uqckV5sZzpQhrLz5TyeFxEHVP6jbZP+rOK6SqacPN0eZ+R9og67eoaIq6XqEryZE0+2/SbXVbYYCTE5wCGhM/nlhc1MF1FY1iVmGUq5hdm1yvlejcacGG21MwSHZjaZyTglhU2vR1oej2UVCnENsY6rgpAm8S2xrWVene4Y101ViWG2bsJq8v0rtGvlKvNrY2YroKFxLbGkqqmP+6mf1yolEQhV+m4KgBtUijUKpXe/YRXKomag1WJSfW1CsJhuohn1EsUaqXefV1ZQCFX85o5gQB9LAAAwH5IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7Ie0AwAA9kPaAQAA+yHtAACA/ZB2AADAfkg7AABgP6QdAACwH5NpN37ikL0/7ny+aVevWbrkX29puaCmjJsQ+dxFvojKyoqIyNCLl862/6LBsGRlZUREhiYnJz7f5Pq8KlF/2r17d3VWFJsdPhI75OU+zz35i2yf9RPL23Zr1i77/Y9jTFcB/9iEV4YWFOYzXQX8D1YlaJIBraosT7tHj+4zXQL8Y0VFhZWVFUxXAX+DVQmeZVirqtbSTqlUxh7YO2JU/xGj+i9e8ibdr5Kdnfndpi9nzo4aNiJs3vzpx44fanLy3Nyche+9HhEZOm36uO3//k4mkxFCqBnSrykuLoqIDI2Lu9xo2uYWEREZWlhUsH7DJ2PGDaIeOXX6xFsLZo0Y1f+tBbMOHd6vVrf1ihu/Hv1l3vzpo8cO/Ojjf2l+unt/3DltxvhhI8JmzJy48etPVSoVIeTBw9SIyNAHD1Ppl02fMX7rtm+oUqmnVn20JCIydFL0yG3bv1UqldTLzl84PX3G+LHjB3/x1eqKinLNAo78euCDpQvGjB30yqvD1n6yPL8gj3r88JHYV14ddjXuUuTQ3t9898WIUf33/bRb80MZO37wv2M2tfCn/XJw3/iJQ65evTQx6uXBQ3pN/78JZ878Rj+bmnrvg6ULxo6LmDFz4tZt30gkkmeXu/n7DYSQ6prq9Rs+iYgMHT9xyLpPPywuLqJeWV5etu7TD6Onjh4/ccinn6968uQx/ak1+VbcTbw9ZdoYQsi06eM+/WxlGz8gNmFwVbp27cqnn62cPGXUiFH93188/27ibepxna5KaekPIyJD/7xyYe7r0RGRoVGThn+/9WvNSRpkDVu3fTN5yqhJ0SO3//s7en3paJpbxZr71DQ196UaMap/7IG99Mu+Wr923vzpz07e5PZHc1Vd+dFiQohCofh3zKbZcyeNGjNg6fJ3r1+/2pa/6/qNuPfenzdiVP9pM8Z//uXHZWWldCf29etXoyYN3/3Dtud9z/5Ga2kXs2PzsWMH167ZsHLFp3Z2DkuXv5Obm0MI+X7rxlu3ri18d+kXn28aOXL8d5u+vH4jrtG0RUWFC96ZHeAfuHHDtsmT/+/8hVObNn/V9kU3t4hTv8cRQv61ZNWJY5cIIefOn/ryqzU+3t327zv+2ty3Dx3ev2XrxrbM/48/jlVUlM2fv+jD5esSE29v+X4D9fgPe7YfPfbLm/MWHTp4eu6cty5dPnvw0E8tz8rIyIgQsvHrdZGRw8+cuvbh8nW/HNxH7ZzLysr49LOVL788et+PR4e9PHrzlvX0VMnJiZu3rPfz67l27YZlS9dUVJTTMWBsbFxXJzl+/NDyZWtffWVqxKCXz53/g57wbuLtmprq4cPGtFASj8eXSGrPXzj104/Hjv56PnLwsC++Wk1lUl7+kyUfvCVtkG7Z/MMnazZkZaW/9/4bCoWi0XInjJukUCiWLX+3tKzk643b31nwr6clxctWvKtQKJRK5XuL5yUmJby3aMXunQesLK3fensmtao091YEBYZ+/um3hJCf9h37cMW6tnxALMPUqiSVSj/9fGVDQ8OypWs++/Rbd/dOH658r7y8TNerEp/HJ4Ts27dr3Sdfn/4j/u23Fh87fvC334/SU23a/JWPT/dlS9dMmzrnwC8/dswO1eZWsRY+NU3Nfanaorntj+aqum7tRuqTOnR4/4Txk/f/dGLggMiP13xw+c/zLc88Lf3h8hULg4J67dl96N13PsjMTPvyq9X09mHvvp2TJ80YPnzs875tf6OdS8VXVVf9cnDfooXLeoX2JYT06RNeVycpKy91d++0atXndXUSJ0dn6t05der4zVvxffuEa05+6PB+gVA4e9Z8Ho8XHNTL2Nj4H3WbtGURhJDffz/ao0fQooXLCCFWVtazZ87/asPa6VPnWFlZtzx/E5Fo9qz5HA6HEDJ69MRDh/fLZLIGWcPPsf95c/57/fsPIoQMGjgkKyt930+7Jk6IbrXggQOGDBo4hBDSs2ews5NLWtqDIZHDjx0/6GDv+H8zXqP+ivLyMvo3mq9vwA+7fnF1defz+YQQhVy+YuV7VdVVYgsxh8ORSqXR0TODg3oRQkaNHP/HqePpGY+8vboSQi5fPtetq6+HR+eW61EoFBMnRJuYmJgQk1kz5x05Env+wulZM984d+4PI77RJ2s2iMWWhJAli1dNmTbmatylQQOHNFru1bhLDx6k/OeHQ+7unQghbm4evxzcV15eVlCQl5ubs3HDNuplb85fFBd/+fDh/e++80ELb0WrbyCLMbgqCYXCnTGxJiYm1MfdvZv/seOHklMSBw6IbPRK7a5K1FMvvTSY+tMiBg09d/6P8+dPjRo5nnoqJLg39a0ICgw9febkxYtnxoye2OZ3lCWu37ja5Cpmb+/Q6qfWwpeqLYtuYfuj+bKGhobTZ05OnTJr7JhXCCEjR4xLSUna++OOZ78/mlKSE4VC4fRpc7hcroODY7euvlnZGYQQ6kvSK7Tvq1HTXuBt+xvtpF1OdiYhpFs3v79myuevXfPfpolafeRI7I2bcXQXlpOTS6PJs7LSvb278f57xdnhw8a03BxprA2LUKlUKalJ/zfjdfqRoKBeKpXqXvLdlj8MQkhoSF/qrac+eHmsvLSspLKyQi6Xd+/uT7/Mx6d7bW1tfv6TVuv18elO3zYzM6+trSGE5Oc/6dS5C/04/WYSQng8XkFB3vdbNz54mEL3JVZWlNPftm5d/3qxn18PV1f3c+f+8PbqqlarL/95ftbMea3Wo1kSh8NxdnbNzc0mhKSmJnXr5ketRYQQR0cnZ2fXe8l3qXzSXG5mZrpIJKJXHh/vbitXrCOEnD5z0sjIiIo6auaBPUOS7t1p+a3oyJhdlerqJDt3bUlMSqB6k6hjgxu9RuurEnWX+n1GcXF20+yi6BXaj77t2z3gatzFtv9FrNHcKtaWT62lL1UbtLr9oaSlPZDJZJofVmDPkD9OHX82FzX5BwRKpdLlHy4KDenTr98AVxe3oMBQ+lkf7+7NTfgctJN21EZKKBA2elylUi1bsVAul73+2oLAwFBzM/N3Fs59dnKJpNbS0ur5Ft3GRchkMrlcvmv31l27t2o+3mj3WJNEIlP6tomJiBBSVVVZXl7a6E+mnqqvryP/XZ+bw+U20YFcXV3l6ur+v7kJTejbcXGXV360eNrU2fPeWNili/fthBsfLF2gOa2xsTF9e/zYV/ft3z1/3sK7ibfr6+uGDBnR6h9ICBEIBP+7LRRKJLXUx/rw0f2IyFDNV1ZodJLQy5VIagXPfPrUHORyeaM5aH7WTb4VHRmDq1JxcdHC914LDuq96sPPfH0DOBzO0GF9n32Z1lclgbGAECLU+MIL//sNpJiammnMQVRVVflcf59ha24Va8un1tyXqo1a3f5oLuXZr2VFeVkLaefj3e2Lzzf9+ef5mB2bt277JiS496yZ8/z9e1LPGmtsl16cdtKO+jrW1UkaPZ6W/vDhw9QN67eGBPemHqmtrbGztX92cskz0z5LqWpi73QbFyEUCkUi0ctDRw34+89PZyfXVpcrldbTt6mVUCy2pB6s13iK+vOtrW3LKxp3miuUilaXYmEhljZIG82NcvL3XwMCAl+b+zb9B7Ywn6Evj9oe893thBvXrl8J6zfAwtyi1UUTQiQSianpX1uiBqnUytKaEGJtYxsQEDh71nzNV4otLJ+dXCQyra+vU6lUjdLLxsbWxMTk03XfaD7I4/LaUlLHxOCqdOnyWZlMtmzpGhMTkyZbdRTtr0r19Y2+1VKpVDP8/jZVnYTubOhQmlvF2vKpNfelelaTX4w2bn9sbO0IIYvf/9DFxU3zcXt7x5YX2qd3WJ/eYbNnzU9IuHH4yM8rPlx05LBOzjPWzi9rL6+ufD6f7qFSq9XLViw8ffok9SuMXidzcrJycrKenbxrV9/U1CTq8Afq0MQl/3pLqVQaGRk3NDTQj+c+zn522jYughDSpYtPTW1NUGAo9c/fr6eNta29vUOrf11GxiP69qNH942Nje1s7bt08eHxeKmpSfRTDx6kmJuZ29nZU79V6+vrqMdra2tLS0taXYqDg9ODBynUUZ2EkGvXr9BPVVdXaW7Xrly50MJ8LMwtBg0ccvnyuQsXTg8dMrLV5VLuJt6ibjQ0NOQ+yencuQshpIun99OnRT17BNNvmpWldZN9/d26+kql0kdpD6i7ubk5i95/IzMzvUsXn/r6ent7R3oODg5OXhp9VtAIg6tSdXWVubkFtdEkhLRwfIF2VyXqbmJSgubLPDt70XfT0h9qTuXi/LeNaQfR3CrWlk+tuS8VIcTYWEBvqQghdCe5pjZuf1xd3KkuIvqL0cnD08O9s0gkauHvSkyp9GPMAAAgAElEQVRMuHEznhBia2s3bNjot99aXFNbU1Rc2LZ35Z/RTtqZmZkNHTLy2LGDf5w6fjfx9uYt6xMSbnTv7t/Jw5PP5x/45cfqmurc3JzNW9b3Cu377F8yauR4mUz29Tef3U64ceXqxR07N9vY2vF4PF/fALVafer0CarBvj92z7OLbmERAoHAzs7+9u3rdxNvKxSK1+cuiIu79Psfx1QqVXJy4tpPlr+/ZD69k7wF2TmZvxzcp1Qq09Ifnj5zcsBLg42MjCzMLYYOGbnvp93x8X9W11SfOfPbr0cPREVN43K5bm4e5mbmv/9xTK1WKxSKL7762LwNDaxBg4ZWVlZs3rJerVbfTbx99Ogv9FNeXXxu/fevoA/7bOELMXLkeGq3R9++/Zt7jSYul3vkSGxubo5Sqdz9w7aGhobIwcMJIVFR01Qq1ZatG6VS6ZMnj/8ds2nOa5OpfciNhIb2dXFxi4nZdOXqxVu3r3/73RclT4s9PDqHBPfu3Ttsw4ZPiouLqqoqjx47OP/NGadOHW+5Hjf3ToSQS5fO0ut2x8HgquTp6V1WVnr8xGGFQnHjZvydOzfFYsunT4t0vSpRT926fY3a6l2Nu3Q38bZmD/yFi6epp86e++PBg5SIiJdf+G02PM2tYi18arTmvlTU3tPLf56vra0lhPy4b1dp6dNnF93C9odeVe8/SBGJRLNmztv7447k5ESZTHb5z/NLPnjr2+++aPnvSklNWr3mgxMnj1RWVtx/kHLk11hbWztHByetvnl/0U5PJiFk4btLv/3ui41ff6pUKr26+KxdvZ5qBHy4Yt1/9saMGz/YxcXtw+WflJWXrvpoyczZUf/54X9nC7m6un/x+aYNGz7549RxgUAw7OXRr722gBDSvZvfm/MXxcRs2vj1p76+AW+89s6i999odGaPg4NjC4uYNnXOD3u237wV//P+kwEBgTHbf/pp/w//jtkkldb7+fZY98nXgtb6hRUK+ZTomamp97Zt/9bU1LRXaL8Fby+hnnr7rcVcLveTT1coFApnZ9epU2ZPiZ5JHTu7atXn3236cvCQXra2dvPeWFheXtbqCUm9QvvOn7fw+PFDg4f0cnBw/HD5uncXvUZNNWfOW3V1kpWr3q+vr584IXrZ0jWFhfnLlr/b3AH6QYGhfD5/6JCR1DFUreJwOJNenf7+kvllZaUmJibLPljt5uZBNRN37TwQG/ufeW9Oz83N6dbN719LVvl4d3t2Dnw+f8NXWz//8qOPPv4XIaRfv5c+/+w7aumff/rt8ROH165bfv9+spubx5AhIyZObOWwVRdn1+HDxvywZ3tySiJ1iHOH8k9XpY9X/W+D8iKrUuTgYY8fZ+39ccc3337eK7Tv0g9Wxx7Yu//nPTU11e+/t0KnqxIhZGr0rF27vl+2/F0ulztxYjR1QKZcISeEvDb37Zgdm5Ytf9fOzj568v+N0NLx6IaluVWshU/Nw8OTnry5L9WCt5ds3LhuzLhBfD5/8qQZkYOH37lzs9GiW9j+DIkcTq2q/n49v/n639GT/69LF5/9sXvu3Llpamrm59tj8eJWTpmd9Or0ysqKLd9v+Pqbz4yNjQdHDPvm65g2brj+KU6TW+Ebf5TL5aTnwFaOJwb99CjtwZtv/d/ePYc1D3tpzuEjsVu3fX3+bOOvuMG5fbZMbMMNjnjOYzR0JO5EGZfP9Q/Tr6r0SlZWxtzXo7/7ZkePHkG6mP+xrY9HzXGycjBuw2vbz09fPB4Y5SS206+qWCDxUrlASHoPayK8dBKhwJSMjLTi4sKYnZunRM9sS9QBAHQQSDsyZuyg5p5aunR1//Bmn9VDMTs23bp9fejQkXNmv0k/uP/nPT//3MR+GkKIRyfPiEEdcS8IaF1ycuKKDxc19+y+H492zGMpoeXtz5ZNu5t8SheQdiQmZn9zT1EH4huQr77c8uyDY8a80tyOfT6Pb2dn/0prO9IAWhUQENjCqtRC1Hl6el0838TQjsAOLW9/2rMSpB2hxitiMXMzc3Mzc6arAPZj/aoEz0F/tj8YyQIAANgPaQcAAOyHtAMAAPZD2gEAAPsh7QAAgP2QdgAAwH5IOwAAYD+kHQAAsB/SDgAA2K/ptBOIuHwjBCEYEiMjjlCkd1dFNzHl8Xgcpqvo0MytjXn6tzWzdDBWtXIRMHge/Oa3A01/CazsjYty6pp8CkA/FWTXWdnr3fVTxLb84tx6pqvouGRSVfHjegtrvRsiUSDklhVIma6ChQqz66zsjZp8qum0c/MRyeqVKqWO6wLQEnmDisshjh5CpgtpzL2rqaRKwXQVHVdhdn3XUL0YpLERTz+z8sIGpqtgG6VCrZCpXbxFTT7bdNpxeSR8nO35/fk6rg1AOy78XDhggh1H7/qriJGA03eEzbmfCpgupCMqK5AlXiwdONGO6UKa4NnDVGDCSThXxnQhrHJ+f8FL42y5zWwHmr52OaU4t+FETH7PQTaWtsZCU73bIwIdHYfUVStqKuS3z5RGLXSzdda7bkxafkb96X1FAf2tLe0FQhP9y2R24XA5lU8b6msVaQlV0YvdeUb6u9/0ytFSeYPa0l5g4yxsbhsNraqvVVaVye5eLBs/38XeTdDcy1pKO0KIVKK8c7Gy5EmDpAa9MVqgVpOKigprayumC2EDLo9jYsp1cBeGDrHmG+vvFo0iqVIkXqoqK2qoNaiOTYVCKZFIxGILpgv5B8S2xlyu2snTJHCAAVw/NitZknNfIpOqyotlTNfSNKVSWVtbKxaLmS6kWSJznr2bMGSwlUDU0k+GVtIOtEsmkw0aNCg+Pp7pQgDaJC0tbfXq1fv3N3uZVmC9zMzMFStWHDhwgOlCXhQazwAAwH5IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7Ie0AwAA9kPaAQAA+yHtAACA/ZB2AADAfkg7AABgP6QdAACwH9IOAADYD2kHAADsh7QDAAD2Q9oBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAf0g4AANgPaQcAAOyHtAMAAPZD2rU3tVrNdAkAAP+AQqFgugQt4DNdQMfC5/OHDx8+YMCAgIAAf39/Pz8/f39/a2trpusCaBqXy3V3d2e6CmBAdXV1XFxcfHx8XFzcrFmzmC5HCzhoarS/urq65OTklJSU1NTUlJQUExMTOvn8/f25XDS4QV+kpaWtXr16//79TBcC7eT+/ftUyD1+/Dg8PDw8PDwsLMzCwoLpurQAbTsGiESiPn369OnTh7qbn59PJd+5c+dSUlK6d+9Ohx9+VgOArtXW1sbHx1PNOCcnp/Dw8MWLF/v7+zNdl5Yh7Zjn4uLi4uIybNgw6i7V4Lt+/frOnTurqqo0m33s+IUFAPrg4cOHVMhlZGSEhYWFhYUtWrTI0tKS6bp0BWmnd/z8/Pz8/KjbVVVVVLMvNjY2JSXFysqKDj9fX1+mKwUAAyOVSum9cba2tmFhYQsWLAgMDGS6rvaAtNNrYrGY6jqn7j5+/JgKv5MnTz58+FDzUBdnZ2emiwUAPZWRkUGF3P3796lm3Jtvvmlra8t0Xe0KR6kYKpVKpXmoS0NDg2afp0gkYrpAYAMcpWK4lErllStXqGachYUFFXIhISFM18UYtO0MFZfL7dmzZ8+ePam7ZWVlVPLt2bMnJSXFycmJDj8fHx+miwWAdvL48WNqb9zNmzcHDBjQr1+/uXPnOjg4MF0X89C2Y6fMzEy62ff48WOqwUeFn729PdPVgcFA285Q0AdVcrncsLCw8PDwvn37Ml2UfkHasV9DQ0NKSgodfhwOh06+gIAAIyMjpgsE/YW002f5+fn0ISf9+vULCwvr37+/q6sr03XpKfRksp9AIAgJCaH764uLi6nk2759e3JysqenJx1+np6eTBcLAK24ceMG1ZKTyWTh4eFRUVHffPMNh8Nhui59h7TrcBwcHBwcHCIjI6m7jx49SklJSUxM3LdvX3FxsWafJ4Y0A9ATRUVFdF9lcHBwWFjY+vXrO3XqxHRdhgQ9mfA/EolEs89Tc0izgIAA/HjsgNCTyayEhAQq4Wpra6mDKvv378/no5XyPPCuwf+Ympo2N6RZcnKyr68vhjQD0LXS0lJ6b5yfn19YWNi6deu8vLyYrsvgoW0HbUU1+Kj/NYc0CwgIMDc3Z7o60Am07dpNYmIi1VdZWlpKjcUcHh4uFAqZros9kHbwPOghzVJSUpKTk62trTGkGSsh7XSqsrLy6tWr165di4uL8/Lyovoqu3XrxnRd7ISeTHgeLQxp9ujRI/pQl4CAACcnJ6aLBdAvKSkpVEdlQUFBeHj4gAEDli9fbmZmxnRdLIe2HWiZUqmkD3VJTk6WyWSafZ4mJiZMFwitmzFjRnl5OSFEJpNVVVXZ2dlRt8+ePct0aYaqtrb26tWrVMi5ublRHZX0+O/QDpB2oFv0kGZUn6ezszOGNNN/O3fu3LFjh1Kp1HzQ3t7+999/Z64og/Tw4UMq5LKzs+m9cWKxmOm6OiKkHbSr5oY0CwgIoBoQoA+qqqpef/31rKws+hG1Wj127NiPP/6Y0boMQ319fVxcHHVcpb29PRVyPXr0YLqujg5pB4zRHNIsOTmZy+ViSDP9sWvXrh07digUCuqug4PD5s2bMdpOC9LT06mEe/DgQf/+/alDTmxsbJiuC/6CtAN9QQ9pRvV50kOaBQQEdO7cmenqOpzy8vL58+fTzbsxY8agYfcsmUxG7YqLi4ujDt0KCwsLDg5mui5oAtIO9BQ1pBnV7Hv69Klmn6eVlRXT1XUIu3fv3rZtm1qtRsOukezsbCrhkpKS6L1xuLqInkPagQHQHNIsOTlZJBLRyefv748hzXSkoqJizpw5T548QcOOun4yPcSJQCCg+ip79erFdF3QVkg7MDz0kGbU1dvpIc0CAgLc3NyYrk6r1KS0UEYIYyvpgQMHzp0799FHHzH4xhoLeBY2jJ0ZnJubS4XcjRs3qHNMw8LCnJ2dmaoHnhvSDgwePaRZcnJydXU1O4Y0qy6Tx/9WnpFY4xlgXlnSwHQ5TDIW8MqLG/z7icPGtN8RH9euXYuPj7969SqHw6ESrl+/fu22dNAFpB2wSpNDmnXv3p3a7cd0dW1VWaL4dWte5BRnKwdjpmvRC7J6VVZKTWGWZOzrzkRn/dYFBQVUM+7q1at9+/alWnJs6y3owJB2wGbUkGYPHjygIlDz6n16e4lnSbXy5/W5k5fgMNTGsu7VPn5QPfYNLfci3rx5k9ob19DQEP5f2BnMPkg76ECo/XxUy08ikWj2eZqamjJd3V/Oxz7t5Gdh747B75uQcLbMvavQM+BFP6zi4uK4uLhr165dvXo1KCiIum4cLo7Kbkg76KAqKio0+zzt7e39/6tr164MFrZzZdb4tz0EIh6DNeit5KsVRK0KG/2cO/ASEhKoCw5UV1fTZw5gHIMOAmkHQKgzqFL+Kysri2rwUS0/BweHdiujrlZ56j/FQ6fjkL+m5WdICjIlgyf978y2+Pj4tWvXnjp1qrlJysrK6DMHfH19+/Xr179/f1wctQNC2gE0JpfLqQYf1fJTqVR08gUEBBgb6/DIEalEte/znMn/wnncTct9KMlJqR4196/LSJ08eXLz5s2lpaUJCQmNXpmUlEQlXElJCdWM69+/Py6O2pHh+nYAjRkZGQUFBQUFBVF3S0pKqOSLiYlJTk7u1KkTfXofhhdh0P79+3fs2FFTU0P/ZK+srKSacfHx8Z6enmFhYStXrsTFUYGCth3AP5OWlkaf3ldUVOSvwdra+gVnjrZdy+i23bZt22JjYyUSCfW4SCTy9PTMy8uj98bh4qjQCNIO4PnV1dWlaBAKhXSfp7+/P5fLbXny0aNH9+rVS3NQLqRdy6i0Sy378ejRozKZTPOpPXv2GNApldD+0JMJ8PxEIlHv3r179+5N3S0oKKD6PM+dO5eSkkKd1U6Fn7u7+7OT19TUnDhxIicn57vvvrOwsGj38g1Sekb6wXMHG/1MV6lUiDpoGdp2ALpCD2mWkpJSVVWlOZI1NaRZSEgIh8NRKpUeHh4fffRRcHAw2nYty30oufRbcvLTPWVlZQqForKysrq6mrrYrKur6/Hjx5kuEPQX2nYAuuLn5+fn50fdpoc0279/f0pKCjWkGfUUj8fLy8tbsWLF7Nmzx41+ldGSDUAnD4+3126Xy+VZWVm5ubmZmZkZGRlPnjypqqpiujTQa2jbATDg8ePHc+fOrays1HxQJBINHjjcVR2Ntl1zGp2BANB2rexFBwBd8PDw4PP/1rOiVqvr6+uvX7/OXFEAbIaeTABmVFZWqlQqDodjbW1tbm7u7u7es2fPrl4B908zXRkAGyHtAJghFos7deoUHBxMna4gFoupMxDun85hujQAFkLaATDj9Gk04gDaD/bbAQAA+yHtAACA/ZB2AADAfkg7AMOmVqsPHd7/+htTh48Mnzd/+o6dW5RKJSEk9sDeEaP60y8rLi6KiAyNi7tMCFmzdtnaT5afPfv7y8P7jRjV/73351VVVf5n747BQ3qNnzhk2/ZvqdNws7MzIyJDU1PvLXzv9YjI0ClTxxw7fig3N2fm7KjIob3ffmf2w0f3qZlnZ2d+t+nLmbOjho0Imzd/+rHjh6jHs7IyIiJDr1+/GjVp+GtvTPlhz/aRo19SKBR0VYcP/zx0WN9GI14C6ALSDsCwHTkSu++n3VGvTI3df3LMmFd++/1o7IG9LU/C5/NTUpNSUpMOHvhj+9YfU1KTFr73ukqlPHn88scfffHLwX03bsRRVz4ihGz5fsPM/3vjwrlbfv49d+zc/O13Xyz9YPXpP+IFxoJNm7+iZvj91o23bl1b+O7SLz7fNHLk+O82fXldYw579+2cPGnG4vdXjhn9Sn19/ZWrF+lKLl853z98kE4vGQhAwTGZAIYt6d6drl19hw0bTQgZPWpCUFCv+rq6VqeSyWQL3l5iZGQkFlt6dvZSKBWzZ80nhAQFhlpaWmVmpfft+1e7MDJyeHBQL0LIoAFDzp8/NXZslG93f0LIgAGRW7d9rVarORzOqlWf19VJnBydqTmcOnX85q34vn3CORwOIaRXaN9Xo6ZRc+sV2vfChdMRg4YSQsrKSpOTEz9b942O3yEAgrQDMHj+/j1jdmz+av3aHj2C+vUb4OLs2papXFzcqIYXIcREJLKxtqWfMhWZ1tbW0Hfd3Dr99biZGSHEs7PXX1MJTeRyuUwmEwgERK0+ciT2xs24J08eU886ObnQc/Dx7k7fHjly/KefrayqrhJbiC9dPicWW/buHfZibwBAmyDtAAxb1CtTRSLTuPjLX361hs/nDxo0dN7r79ra2rU8VaNr77VwKb5WX6lSqZatWCiXy15/bUFgYKi5mfk7C+dqvsBYIKBv9w8fZGpqdvnyubFjXvnzyvmXh47i8Xht+0MBXgjSDsCwcbnc0aMmjB41IScn686dm3v2xkgktc92DypVSh0VkJb+8OHD1A3rt4YE/3Wdv9raGjtb+yZfzOfzRwwfe/bc7wMHRN67d3fhO0t1VBVAIzhKBcCwnT59Mjs7kxDSqZPnxInRr0yckpHxiBBiZGTc0NBAHwCZ+zhbRwVUVVUSQuh4y8nJysnJauH1o0ZNSElJ+uXgPh/vbp6eXjqqCqARpB2AYTt/4dRHq/8VH/9nVXXV9etXr1y94O/XkxDi6xugVqtPnT5BnX6wP3aPjgro5OHJ5/MP/PJjdU11bm7O5i3re4X2LSoubO71ri5ugT1DDh/5edjLo3VUEsCzkHYAhm3x+ys7eXh+uOr98RMi12/8JDxs4PvvfUgI6d7N7835i2JiNkVEhq5dt3zu7Leok/O0XoCDg+OHK9bdf5A8bvzgFSvfe23u22PHRj14kDJzdlRzk4SFDVAqlZGRw7VeDEBzcDVXAD0ilaj2fZ7D+qu5Lv9wkbm5xYpla//phLiaKzw3HKUCAO2ktrY2PePh3bu3UlOSdu/6helyoGNB2gFAO3n8OOv9xfPt7OzXrFnf6jkSANqFtAOAduLn1+Pi+dtMVwEdFI5SAQAA9kPaAQAA+yHtAACA/ZB2AADAfkg7AABgP6QdAACwH9IOAADYD2kHAADsh7QDAAD2Q9oBAAD7Ie0A9AmH2LoKmS5Cf/F4HDNLjHcIzwNpB6BHhCJu5VOZpErBdCF66mme1MScx3QVYJCQdgD6pUtPs/JCGdNV6CmpROHSRcR0FWCQkHYA+uWlcbaXDhVKJUqmC9E7t06XCoQcly7o6YXngWuXA+gdhVy9a1VW+DhHc2u+tYOgg6+jCrmqtKAh90GtmSWv7whrpssBQ4W0A9BT106W5TyUGAt4RTn1TNahJoTD5PJtnAUCE65fH7FPiBmTdYCBQ9oBQLPS0tJWr169f/9+pgsBeFHYbwcAAOyHtAMAAPZD2gEAAPsh7QAAgP2QdgAAwH5IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7Ie0AwAA9kPaAQAA+yHtAACA/ZB2AADAfkg7AABgP6QdAACwH9IOAADYD2kHAADsh7QDAAD2Q9oBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAf0g4AmsXhcDp37sx0FQBagLQDgGap1ers7GymqwDQAqQdAACwH9IOAADYD2kHAADsh7QDAAD2Q9oBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAf0g4AANgPaQcAAOyHtAMAAPZD2gEAAPsh7QAAgP2QdgAAwH4ctVrNdA0AoF/eeOONqqoqLpcrkUiePn3q4eHB5XLr6uqOHTvGdGkAz4nPdAEAoHe8vb0PHDhA383MzCSEODg4MFoUwAtBTyYANBYdHe3s7NzowR49ejBUDoAWIO0AoDE3N7eXXnpJ8xEnJ6cpU6YwVxHAi0LaAUAToqOjXV1d6bv+/v5o24FBQ9oBQBPc3Nz69u1L3XZwcJg6dSrTFQG8EKQdADRt2rRpLi4uhJBu3boFBAQwXQ7AC0HaAbCOiqi18c/VxS2sX7jYwnL6tBlamaFaxfQ7Ax0YzrcDMHgleQ2Z9yRP82SVJbJ6iUJsIygrqGe6qKYJzfhETUzMePbuJs6djT39zYSm+M0N7QFpB2DAbp6uvHe1gmfMM7USmVqb8I14fAGPZ6S/+aFWE0WDUtGgUCpU1U8lNSUSly6mPV4yd+8qYro0YDmkHYBBSvqzKv5kqW0nS0tncyMBj+lynl99tawku1woJINesbV3EzBdDrAW0g7AwCgU5NCmfMI1svey5vI4TJejHbXl0tqSGo9uwn7DLZmuBdgJaQdgSOQNqh/W5rj4OphaC5muRfuK08qs7cjQqfZMFwIshLQDMBgyqergpgKHrg58Y/3dM/eCSnMqnVy54WOsmC4E2Ia16wwA+/ywJsexG5ujjhBi28myKF/156+lTBcCbMPm1QaATQ58k+fWw0Gfj7fUFhsPy4IcxYOb1UwXAqzC/jUHgAXuXKzgCYUiSxbuq2uSYze7+N/KG+pwOjpoDdIOwADEnyyz9ehYu7Js3C3/PIr+TNAapB2Avos7UeboZUVYcq5BW1k6mz9+WFdVKme6EGAJpB2Avku9Xm3tasF0Fc1av3nK4RNf6WLOVi7ixMtVupgzdEBIOwC9lp9ZLzQ14vI74qpqbifKSqllugpgiY64CgEYkPTEWpF1Bx1D0tiETwinvEjGdCHABnymCwCAllQ+VZjbmulo5kql4o9z2x+kxVVWFnX26BnW51XfruGEkMLizI1bpr47b/eFP/+T8uCy2MI+MGDoyKFv83g8QkjR06zYw2uLS7K9PEOGDJyjo9ooFvamhTlSa0djnS4FOgK07QD0Wkm+lGekq0Gffz254cq1n/v3eXXF4qMBfoP3xi67l3KBEMLnGRFCDh77PKjHsC8+vjo1as3luJ+SUs8RQhQK+c69iyzF9h+8e2DUywsuXd1XU6PDIydVak51OQ5UAS1A2gHoMTVpqFPydXOJA7m84Xbib4Nfmtmv90RTkbhPyNigHsPOXtpFv6Cn3+Ce/pF8vlGXzsE2Vi55+Q8JIcn3L1ZWFY8d8Z6VpaOjveeE0UvqpTW6KI/CN+bVVCh1N3/oOJB2APpLUqO0c9PVTrsnBQ8UCpmPVx/6kS6dgguLMyR1fx0G6ercnX5KKDSnUq207ImxkdDayol63MLc1lLsoKMKCSHGJkako517AbqB/XYA+svEjFeaV+fQTSczl9bXEkK+3/lGo8drast4XD4hhMNp4tdwXX21seBvAWzE1+EILzKpgm+MEVVAC5B2APqLyyVGAq5SpuLpYCRoCwtbQkjUuOW21m6aj1uJHaub3xUnMrFoaKjTfETaINF6bTRFg8LcAZsp0AJ8jQD0moWNsUKm1EXa2dm4GxkJCCFeniHUIzW15Wq1WiAQkeb3xFlZOsnl0sLiDCcHL0JIfmFadU2J1mujqZVqcysj3c0fOg7stwPQa7bOxpJKqS7mLBCIXo54/ezFXVmPE+UK2b2UCzF73jlyspVRUfy6D+DzjQ8e/Vwmk1ZVl+z7ZaVIJNZFeZT6qnp7t44yFjboFNp2AHrNO9DsyokKa1dzXcw84qUZzk4+F6/sTc+8JRSadXILeHXcipYnMRGazZ3+9W9ntqz8dLCxkXDUywvu3Duto8NIFDKlTKpwcBfoZvbQseDa5QD67vvFGb6RnTkd78jE8vwaC1PZkCn2TBcCbICeTAB95x9mWV3UEYeLlFZIAsJ02E0KHQp6MgH0Xb9R1rtX54idmh0/bHPMa8Ul2c8+rlIp1Wo1j9f0ar5s0WEzU0ttFXnhz/9cuLK3mSc5hDTdh7R04UFzM+smn6p+KrGw4jp4oBsTtAM9mQAG4Orx0qdFXGu3phs6VdUlSmXTw2vJ5A3GRk0HhrWVsxYrrK+vaW5QFUldtamo6SsWiS0cqLE3n5V5/UnUOy5iWxyQCdqBtGzxnr4AAAF3SURBVAMwDHs/y3Xq7mAk7BD9MeWPK908ub1e7liXawedwn47AMMwZbFbxrU8pqtoD1VFEmMjOaIOtAttOwCDUfFUdnJ3iVtPR6YL0aGqIglHUT/2dR2OvQkdE9p2AAbDyt549By7B5dy5FJ2XhagPLeqoaoGUQe6gLYdgIGRSVX7vsi1cLSw9WDP0flyqaKyoNrGjgyeZMd0LcBOSDsAg3TxYGn63RoHbxuxoynTtbwQlVxVklNRW1o3YLytd7CurtIOgLQDMFR1Ncr4k2WPEqrF9qZmNiJTKxOeMZfLM4AxV5RylaJBWfVUUldeZ2rB7Rpi1qM/e9qpoJ+QdgCGTalQZ6dKslIk5UXyiuIGwuFYOZpIKmVM19U0nhFHUiEzEnCdvUxtnfid/cwwDCa0D6QdAKvIpKq6GqVapafrNd+IZyrmcZs+oRxAh5B2AADAfjgDAQAA2A9pBwAA7Ie0AwAA9kPaAQAA+yHtAACA/ZB2AADAfv8PEYam4XLgaBIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<langgraph.graph.state.CompiledStateGraph object at 0x000001D54DAC9AB0>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "245a7d2d",
+   "metadata": {},
+   "source": [
+    "### Execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "62e74cde",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'runs': 100,\n",
+       " 'balls': 50,\n",
+       " 'fours': 6,\n",
+       " 'sixes': 4,\n",
+       " 'sr': 200.0,\n",
+       " 'bpb': 5.0,\n",
+       " 'boundary_percent': 48.0,\n",
+       " 'summary': '\\nStrike Rate - 200.0 \\n\\nBalls per boundary - 5.0 \\n\\nBoundary percent - 48.0\\n'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "intial_state = {\n",
+    "    'runs': 100,\n",
+    "    'balls': 50,\n",
+    "    'fours': 6,\n",
+    "    'sixes': 4\n",
+    "}\n",
+    "\n",
+    "workflow.invoke(intial_state)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "myenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Agentic AI using LangGraph/5_easy_evaluation_workflow.ipynb
+++ b/Agentic AI using LangGraph/5_easy_evaluation_workflow.ipynb
@@ -1,0 +1,453 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1ab9699c",
+   "metadata": {},
+   "source": [
+    "# <center>Easy Evaluation Workflow in parallel</center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98f2e759",
+   "metadata": {},
+   "source": [
+    "### Import module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "186a9d0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.graph import StateGraph, START, END\n",
+    "from langchain_google_genai import ChatGoogleGenerativeAI\n",
+    "from typing import TypedDict, Annotated\n",
+    "from dotenv import load_dotenv\n",
+    "import os\n",
+    "from IPython.display import Markdown, display\n",
+    "from pydantic import BaseModel, Field\n",
+    "import operator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e972bb7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1e2b9da",
+   "metadata": {},
+   "source": [
+    "### Initialize Gemini Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c4fdabd6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Google API Key exists and begins AI\n"
+     ]
+    }
+   ],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "google_api_key = os.getenv('GOOGLE_API_KEY')\n",
+    "\n",
+    "if google_api_key:\n",
+    "    print(f\"Google API Key exists and begins {google_api_key[:2]}\")\n",
+    "else:\n",
+    "    print(\"Google API Key not set (and this is optional)\")\n",
+    "    \n",
+    "model_name = \"gemini-2.5-flash-lite\"\n",
+    "\n",
+    "# Make sure you have GOOGLE_API_KEY in your .env file\n",
+    "model = ChatGoogleGenerativeAI(\n",
+    "    model=model_name,\n",
+    "    google_api_key=os.getenv(\"GOOGLE_API_KEY\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "410d3224",
+   "metadata": {},
+   "source": [
+    "### Schema Define"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ed5c90ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class EvaluationSchema(BaseModel):\n",
+    "    feedback: str = Field(description='Detailed feedbackfor the essay')\n",
+    "    score: int = Field(description='Score out of 10', ge=0, le=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "71e4adf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structured_model = model.with_structured_output(EvaluationSchema)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "25d4e6ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "essay = \"\"\"India in the Age of AI\n",
+    "As the world enters a transformative era defined by artificial intelligence (AI), India stands at a critical juncture — one where it can either emerge as a global leader in AI innovation or risk falling behind in the technology race. The age of AI brings with it immense promise as well as unprecedented challenges, and how India navigates this landscape will shape its socio-economic and geopolitical future.\n",
+    "\n",
+    "India's strengths in the AI domain are rooted in its vast pool of skilled engineers, a thriving IT industry, and a growing startup ecosystem. With over 5 million STEM graduates annually and a burgeoning base of AI researchers, India possesses the intellectual capital required to build cutting-edge AI systems. Institutions like IITs, IIITs, and IISc have begun fostering AI research, while private players such as TCS, Infosys, and Wipro are integrating AI into their global services. In 2020, the government launched the National AI Strategy (AI for All) with a focus on inclusive growth, aiming to leverage AI in healthcare, agriculture, education, and smart mobility.\n",
+    "\n",
+    "One of the most promising applications of AI in India lies in agriculture, where predictive analytics can guide farmers on optimal sowing times, weather forecasts, and pest control. In healthcare, AI-powered diagnostics can help address India’s doctor-patient ratio crisis, particularly in rural areas. Educational platforms are increasingly using AI to personalize learning paths, while smart governance tools are helping improve public service delivery and fraud detection.\n",
+    "\n",
+    "However, the path to AI-led growth is riddled with challenges. Chief among them is the digital divide. While metropolitan cities may embrace AI-driven solutions, rural India continues to struggle with basic internet access and digital literacy. The risk of job displacement due to automation also looms large, especially for low-skilled workers. Without effective skilling and re-skilling programs, AI could exacerbate existing socio-economic inequalities.\n",
+    "\n",
+    "Another pressing concern is data privacy and ethics. As AI systems rely heavily on vast datasets, ensuring that personal data is used transparently and responsibly becomes vital. India is still shaping its data protection laws, and in the absence of a strong regulatory framework, AI systems may risk misuse or bias.\n",
+    "\n",
+    "To harness AI responsibly, India must adopt a multi-stakeholder approach involving the government, academia, industry, and civil society. Policies should promote open datasets, encourage responsible innovation, and ensure ethical AI practices. There is also a need for international collaboration, particularly with countries leading in AI research, to gain strategic advantage and ensure interoperability in global systems.\n",
+    "\n",
+    "India’s demographic dividend, when paired with responsible AI adoption, can unlock massive economic growth, improve governance, and uplift marginalized communities. But this vision will only materialize if AI is seen not merely as a tool for automation, but as an enabler of human-centered development.\n",
+    "\n",
+    "In conclusion, India in the age of AI is a story in the making — one of opportunity, responsibility, and transformation. The decisions we make today will not just determine India’s AI trajectory, but also its future as an inclusive, equitable, and innovation-driven society.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "46cabf5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = f'Evaluate the language quality of the following essay and provide a feedback and assign a score out of 10 \\n {essay}'\n",
+    "result = structured_model.invoke(prompt)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "c21672a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EvaluationSchema(feedback=\"The essay provides a comprehensive overview of India's position in the age of AI. It effectively highlights both the opportunities and challenges, citing specific examples in agriculture, healthcare, and education. The language is clear, well-structured, and flows logically. The essay also addresses critical issues such as the digital divide, job displacement, and data privacy, offering thoughtful recommendations for a responsible AI adoption strategy. The conclusion effectively summarizes the key points and emphasizes the importance of a human-centered approach to AI development.\", score=9)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "249f7f7d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The essay provides a comprehensive overview of India's position in the age of AI. It effectively highlights both the opportunities and challenges, citing specific examples in agriculture, healthcare, and education. The language is clear, well-structured, and flows logically. The essay also addresses critical issues such as the digital divide, job displacement, and data privacy, offering thoughtful recommendations for a responsible AI adoption strategy. The conclusion effectively summarizes the key points and emphasizes the importance of a human-centered approach to AI development."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(result.feedback))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "8b07b2f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(result.score)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a65a6c50",
+   "metadata": {},
+   "source": [
+    "### Define State"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "5bd6705f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class UPSCState(TypedDict):\n",
+    "    essay: str\n",
+    "    language_feedback: str\n",
+    "    analysis_feedback: str\n",
+    "    clarity_feedback: str\n",
+    "    overall_feedback: str\n",
+    "    individual_scores: Annotated[list[int], operator.add]\n",
+    "    avg_score: float"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "dea3d306",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate_language(state: UPSCState):\n",
+    "\n",
+    "    prompt = f'Evaluate the language quality of the following essay and provide a feedback and assign a score out of 10 \\n {state[\"essay\"]}'\n",
+    "    output = structured_model.invoke(prompt)\n",
+    "\n",
+    "    return {'language_feedback': output.feedback, 'individual_scores': [output.score]}\n",
+    "\n",
+    "\n",
+    "def evaluate_analysis(state: UPSCState):\n",
+    "\n",
+    "    prompt = f'Evaluate the depth of analysis of the following essay and provide a feedback and assign a score out of 10 \\n {state[\"essay\"]}'\n",
+    "    output = structured_model.invoke(prompt)\n",
+    "\n",
+    "    return {'analysis_feedback': output.feedback, 'individual_scores': [output.score]}\n",
+    "\n",
+    "\n",
+    "def evaluate_thought(state: UPSCState):\n",
+    "\n",
+    "    prompt = f'Evaluate the clarity of thought of the following essay and provide a feedback and assign a score out of 10 \\n {state[\"essay\"]}'\n",
+    "    output = structured_model.invoke(prompt)\n",
+    "\n",
+    "    return {'clarity_feedback': output.feedback, 'individual_scores': [output.score]}\n",
+    "\n",
+    "\n",
+    "def final_evaluation(state: UPSCState):\n",
+    "\n",
+    "    # summary feedback\n",
+    "    prompt = f'Based on the following feedbacks create a summarized feedback \\n language feedback - {state[\"language_feedback\"]} \\n depth of analysis feedback - {state[\"analysis_feedback\"]} \\n clarity of thought feedback - {state[\"clarity_feedback\"]}'\n",
+    "    overall_feedback = model.invoke(prompt).content\n",
+    "\n",
+    "    # avg calculate\n",
+    "    avg_score = sum(state['individual_scores'])/len(state['individual_scores'])\n",
+    "\n",
+    "    return {'overall_feedback': overall_feedback, 'avg_score': avg_score}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e78ddd83",
+   "metadata": {},
+   "source": [
+    "### Define graph, add node, add edge, compile and execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "fafde78a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initialize graph\n",
+    "graph = StateGraph(UPSCState)\n",
+    "\n",
+    "# nodes\n",
+    "graph.add_node('evaluate_language', evaluate_language)\n",
+    "graph.add_node('evaluate_analysis', evaluate_analysis)\n",
+    "graph.add_node('evaluate_thought', evaluate_thought)\n",
+    "graph.add_node('final_evaluation', final_evaluation)\n",
+    "\n",
+    "# edges\n",
+    "graph.add_edge(START, 'evaluate_language')\n",
+    "graph.add_edge(START, 'evaluate_analysis')\n",
+    "graph.add_edge(START, 'evaluate_thought')\n",
+    "\n",
+    "graph.add_edge('evaluate_language', 'final_evaluation')\n",
+    "graph.add_edge('evaluate_analysis', 'final_evaluation')\n",
+    "graph.add_edge('evaluate_thought', 'final_evaluation')\n",
+    "\n",
+    "graph.add_edge('final_evaluation', END)\n",
+    "\n",
+    "# compile\n",
+    "workflow = graph.compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "42a914bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk8AAAFNCAIAAACWhRyvAAAAAXNSR0IArs4c6QAAIABJREFUeJzt3XdcE/f/B/BPSEhC2HsPBREQJLhXBQVx71lX66i77lptta3WVqu1v36rbf3a2lpbrVp3raPuOusCBAEXQ7ZAIJAEsn9/XL/X1AIiEi5cXs+HfySXu8s7csnrPp/73B1Hr9cTAAAAVrNgugAAAACjQ9oBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAfj+kCAExXca5SJtUoKrRqpU5ZpWO6nOez5HMseBxrO561HdfFW8gXcpiuCMBUcHC+HcAzMlPkGSnyjBSZf4i1SqmztuU6uvPVymaQdnyhRYVEo6jQyCs00lK1gyu/RRvr1u1srWy5TJcGwDCkHcDfHibKrh0r8Qq08g60ahFuIxQ1767+3EdVmSnykjylq6+g20AXC0QemDGkHQAhhFTJtL/vKhJYWXQb6GznbMl0OY0s4UL5tWMlMaPcwrrYMV0LADOQdgAk71HViR8KR87zcXRnW84Zun68VFmlix7pynQhAAxA2oG5kxSqLh4oHj7Xm+lCmkLyFenTHGXsODemCwFoakg7MGsZyfLEi+Uj5plF1FGSr0gzUuRDZ3oxXQhAk2reB+EBXoa0RH3l1xKzijpCSER3e7/WostHS5guBKBJIe3AfJ3f93TCcn+mq2BAVIwDj8d5mCBjuhCApoO0AzN17bdS32CRhbl+A6JiHC/sf8p0FQBNx1y/62DeVNW6u5el7eMcmS6EMQKRRZsu9nfOlTFdCEATQdqBOUq4UB4zytzHJXYb7JydpmC6CoAmgrQDc3TvmtQ32Kop3/Hx48eDBg1qwILLly8/cuSIESoihBC+lUVGitxIKwcwKUg7MDtFT5Q2jjxR0146MjU1tYkXrI+W4daZSDswDzjfDszO7TNllgJO21ccjLHyysrKrVu3Xr58WSKRhIWF9e/ff9iwYVu3bv3222+pGRYtWjRhwoS9e/deunQpJSVFIBC0a9du7ty5Pj4+hJA9e/Z8//33K1asWLZs2ZgxY/bs2UMtZWNjc+HChUavVlWl+/Wb/JHzfRp9zQCmBm07MDvFeUqRrbHudbV69eq7d++uWLFi//794eHh69atu3v37qxZsyZPnuzh4XHr1q0JEyYkJiZu3LgxMjLy008/Xb16tUQiWblyJbU4n8+Xy+X79+9fs2bNmDFjrly5QghZtWqVMaKO6smUPFVVK5rB7R0AXhLubwdmR16pEdkZa8u/c+fO5MmTu3TpQgh588034+LiHByebURGRETs27fPz8+Px+MRQtRq9aJFi6RSqb29PYfDqa6ufu211zp27EgIUSqVRqqTJrLlKSo0QhHf2G8EwCykHZgdRYXWeAftxGLxTz/9VF5e3q5du65du4aGhv57Hi6Xm5ubu2nTppSUFLn8r8NmEonE3t6eetymTRsjlfdv1rZcRaXWyaPJ3hCAGejJBLNjKbDgco11U+8PPvhg/Pjx165dW7x4cZ8+fb7++muNRvPMPBcvXly8eHFYWNg333xz8+bNLVu2PDMDn990LS2+0AIH78EcoG0HZodnyZFVaGydjLLx29nZTZ06dcqUKUlJSefPn9++fbutre3EiRMN5zl06JBYLJ47dy71tLKy0hiV1JO0VG28o5gApgNbOZgdkS1XUaE1xpqlUunJkyeHDh0qFArFYrFYLL5//356evq/Z/P09KSfnjt3zhjF1JPcmP26AKYDPZlgdly9Bcpqo4xC5PF427Zte/vtt5OSkkpLS3/77bf09HSxWEwI8fPzKykpuXDhQnZ2dnBw8PXr12/duqXRaHbt2kUtW1BQ8O8VCgQCNzc3euZGL1inI86efCsbpB2wH9IOzI5nS6v7tyqMsWZra+uNGzc+ffp02rRpffv23blz58KFC0eMGEEI6dGjh1gsXrp06alTp+bMmdOtW7fFixd37dq1sLBw9erVYWFh8+fPP3ny5L/XOXXq1Js3by5ZsqSqqqrRC358V4aoAzOBs8vBHP13+eOpq1taCow1VqW5+P2nIv9QUev2tkwXAmB0aNuBOQrv5pDzABdEJlWV2hZtrJmuAqApYJQKmKOI7naHv85rGVHrD/1HH310+vTpGl/SaDTUWeH/9sEHH8TExDRalf9Ux5rrKGnfvn1ubjXf7eHO+TIXHz5fiF1eMAvoyQQzotFo0tLSVCpV+/btz+976uYnbNPFrsY5y8vLFYqaG39KpVIgENT4kpOTk1AobNSS/5afn1/bS3WU5O7uzuXWfGRuy5JHcz8NkkrL8/Pzw8LCGq9SAFOEth2wmVarTUtLS01NTU9PT0tLy8rKCgkJefXVVwkhXQe6nN5VWFvaOTg4/PuKX8zy8vJqxLUlXih/ZZgrh0OUSuX69evT0tJCQkJCQ0NDQkLCwsJCQkIa8b0ATAHadsAqVOstLS2NirfMzEz65zs0NLRVq1aGM+fcV9w5XzZ0ljdz9TLj8V35/dsVA6Z4Gk5MT0+ndwvS09NDDbRu3Zq5YgEaB9IOmje1Wk1nG9V6o36ga4y3f0u8UF6Sr4wb795U9TLvaY7y1I+Fk97xr3u21NRU6j82NTX14cOHYWFh9P9qcHBwUxUL0GiQdtDMqFQqOt7S09Ozs7MN4y0oKOhFV5iZonicUhk3ziwCL+dB1fUTpaPn+5AXOflCp9PRzb60tLSMjAzDll8D/s8Bmh7SDkydUqmkf2fT09NzcnLobAsNDQ0MDHz5t0i5Kk2/VTlstjfPks1n4N27Jn2YKBs2+2V7bunuYuovQrWn6e7iRvmLADQ6pB2YHKVSaXjsLS8vj463kJAQI/2YFmRVn9/3tGWEdZf+zsZYP7Oy7smvHCsNamvd2QifjupMTk1NvX//fmpqam5uLt3aDgsLa9GiRaO/I0ADIO2AedXV1YbxVlBQQDfdQkJCWrZs2TRl6PXk1hnJjVOSTvHOvsFWHgHGOpegycgrtJkpsvyMalW1ttsgFyePpriRkOHOSmpqakFBgWHLLyAgoAlqAPg3pB0woKqqynBoSWFhoeGxN2ZbAzodSfqj/HGSrLxEHdbJTk/01nY8OydLna4ZfFN4PCKTahUVWnmFpvypuqxY1SLcOqSDnWcLxpKb2pWhD/sVFRUZDnjx93/OYBmAxoK0g6agUCgMh5YUFRUZxptp7u9XybR5j6orylSKCq1eR2TSRr4FQUpKSosWLaytG/PCXVY2XL1eb23Hs7bjufoI3HxrPuWcQVVVVfRoz7S0tJKSErrZFxoa6uvry3SBwFpIOzAKuVxuOLSkuLjYcGgJ9ugJIZMnT16+fLmZX8RELpenGSgvL6eO9lFbi4+PD9MFAnsg7aBxGMZbWlpaaWmp4bE3xNu/Ie3+TSaTGXZ7VlRUUMf8WrduHRYW1rhXkwFzg7SDBqL3yqkfJsN4Cw0N9fPzY7pAU4e0e66KigrDAS9yuZxu9oWFhXl4eDBdIDQnSDuoL2q/m463srIyw9Yb4u1FIe1elFQqNWz5VVdXG57k7u5uFtcHgAZD2kGtKisrDUdOlpeXGw4twYCCl4S0e0nl5eWGlzdTq9WGoz1ru88RmC2kHfytoqLCcGiJVCo1jDcMGWhcSLvGJZFIDC9vptPpDFt+Li4uTBcIDEPamTWpVGoYb5WVlYYjJ729ze7mAE0JaWdUJSUlVJuP2rYJIYbh5+zMwivmQN2QduaFOvJB90/K5XLDY2+It6aEtGtKxcXFhgNeeDwevWMXFhbm6OjIdIFgdLibK8uVl5cbxltVVRX1De/bt++CBQswpBvMhKurq6ura8+ePamnRUVF1Jdi3759qampAoGAHuoZGhpqajfyhUaBth3blJWVGQ4tocetUSHn6elZj3VAU0DbznQUFhbSzb60tDQrKyvDK7zY29szXSA0AqRdsyeRSAyPvSmVSsN4wzlJJgtpZ7IKCgoMB7zY2NjQZ7iHhoba2toyXSA0BNKu+aHijT78rlarDYeW4Kyj5gJp11zk5eUZtvwcHBwML6RgY2PDdIFQL0i7ZqC0tNSw9UbFG92AQ7w1U0i7Zio3N9fw2p5OTk6G9/MTiURMFwg1Q9qZotLSUsOhJVqt1nDkJOKNHZB27PDkyRP6q5qamurq6kof8wsLCxMKm/1dElkDaWcSSkpKDONNr9cbxhuuCsFKSDtWys7ONmz5eXh40M2+kJAQhB+DkHbMoM7+ofsn6VNfqZBzdXVlukAwOqSdOcjKyjIc8OLl5WU42pPPb4q7yQMF59s1kadPnxoee+NwOFS2jRgxApc1AmCrgICAgICAAQMGUE8zMjJSU1Pv379/+vTptLQ0Pz8/w/P8eDz8IBsR/nONpaioyDDeuFwutVmPGjUKFy4CME8tW7Zs2bLloEGDqKePHj2ifiVOnjyZnp4eEBBgeHkzLpfLdL2sgrRrNNTVGej+SUtLS6q/YsyYMSEhIYg3AHhGUFBQUFAQHX4PHz6kfkOOHz+empoaGBhoOOCFw+EwXW/zhrRrOPr6C9QGKhAIqO1y7NixISEhTk5OTBcIAM1Jq1atWrVqNWTIEOrpgwcPqGN+v/76a2pqauvWrQ27PZkutvlB2r2AgoICw3gTCoVUh8O4ceNCQ0NxYVkAaETBwcHBwcH0U+qXJz09/fDhw+np6fQ4TyoCGa20eUDa1YWKN7p/0srKitqwxo8fj0vHAkBTCgkJMUw16vS+1NTUAwcO3L9/n76TbVhYmGFGAg1p9w/5+fmGQ0voi8NOnDgRF4cFANNBdSxRj/V6PXVVs5SUlH379j1+/NjwPIdWrVoxXaxJQNqRnJycI0eOUPFmbW1N7R8h3gCgueBwOG3atGnTpg31VKvVUrvsSUlJP//8c2ZmJtXyi4+Pj4yMZLpYxiDtyMKFC+Pj4ydPnhwSEoJ4gybj5OSEUXZgDFwuNzw8PDw8nHqq0Wiolt/atWu//PJLs702E9KOSCSS8ePH4y4e0MQkEgmuZARNgMfjtW3btm3btrt27dJoNEyXwxgLpgsAAAAwOqQdAACwH9IOAADYD2kHAADsh7QDAAD2Q9oBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAf0g4AANgPaQcAAOyHtAMAAPZD2gEAAPsh7QAAgP04ZnuHrX79+vH5fA6Hk5eX5+7uzuVytVqtp6fnt99+y3RpwGZ9+/YVCASEkOLiYgcHB0tLS0KIlZXV3r17mS4N2Ck+Pl4oFHI4nIKCAmdnZ0tLS71eb2dnt2vXLqZLa1LmezdXCwuL/Px86nFRUREhRCQSLVu2jOm6gOVEIlFOTg71uLi4mLrT9MKFC5muC1jL3t4+MzOTekxtcnw+f+bMmUzX1dTMtyezQ4cOOp3OcEpQUFB0dDRzFYFZiI+Pf2aKj4/P6NGjGSoH2K979+4cDsdwip+f36BBg5iriBnmm3bjxo3z9PSkn1pZWb322muMVgRmYezYsb6+vvRTLpc7YsQIHs98e1nA2IYPH+7v708/5fP5EyZMYLQiZphv2oWFhYnFYvppcHAwGnbQBJycnPr06UPva/v6+o4bN47pooDN/P39u3btSj8NCAgYPHgwoxUxw3zTjhAyefJkDw8P6lDKxIkTmS4HzMXo0aP9/Pyoht2wYcO4XC7TFQHLjRkzhupR4PP5r776KtPlMMOs065169aRkZHUg169ejFdDpgLV1fXuLg4Dofj5+c3ZswYpssB9vP19e3SpYter/f39zfPhl29xmRWK3QleUp5haZJ6mlqsZ0nFT6yGNxr6P3blUzXYhRCEdfVRyCybR6tB2WVrrRAJStTs/60mA4hQ24HFnTv3j0zWUmIkulyjIsvtHDxEtg6No9jk1q1vrRAVSFRa7Ws2gxfiRr7MEEe2zuWfb911nY8Fy+B0Po5jbfnnG93bu/TJ/cV9s58K5vm8XMJz9DrSX6GwqulVf/XPZiu5TmuHS/Nuqfg8TmObgKNSlePJaB5sBRa5NyXO3sJYse6mfiOV/IV6f3bMo1a5+FnVa3QMl0O1IuiUlNZpvELEfUa7VrHbHWl3a/fFHgFWge3tzNOhdB0ch8o7l6SjJjnbcnn1GN2BlzYX2LBtYjq7cR0IWAsZUWqy0cKh87wtrY30cBLulSR/7iqx3B3pguBhki/KS3Krho0rdbd+lrT7uTOQg9/UaAYUccSxTnVt8+UjF7ow3QhNbh6rFSr5ogRdWynqtId+CJrxsctmS6kBmk3KzOS5T1HmnoXCNTh4Z2Kkryq+Ik176/U3NFZlK1UK/WIOjZx9RU6ugse35UzXcizFBXa3EdViDpzwLeyiOjhlHC+nOlCnqXXk5Qr0i4D3ZguBF5Kq3Z21Qpdca6qxldrTrvSQiVfaKK9DdBgVjbc4txqpqt4lqRIxeWZaP8qNDobB17hE5PbCBUVmspyNV9o1mPU2cFSYFFaUPOwr5r/unKp1t6Fb+SqoKnZOfOrZSY3zExWpnF0EzBdBTQRG0dLjdLkNsJKicbVS8h0FdAI7F35Mqm6xpdqHhOs0+o17B8Ebna0Wr1KZXLDzHQ6vRojMM2GXqevkpvcRqgnpLrK5KqCBtCq9bpa+iXRcgcAAPZD2gEAAPsh7QAAgP2QdgAAwH5IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7Ie0AwAA9kPaAQAA+yHtAACA/Uwx7TIyHvWK7ZCcnMh0IY1p2Ii4nT9+24AFDxzcE9unkxEqgr80+E/TWA4c3BMX35nBAoBxjG+Ezxg9tv+3279sgjfKzX3SK7bDzVvXm+C9TDHtXt6hw/vWffI+01U0jrDQ8EkTpzNdBdQqM/PxuPGDmK4CzN3wkX3yC/JeZg2r1yw/fuJI41XUCF7+Qxmq+R4Izd39+6lMl9BoQkPDQ0PDma4CanX/AXs2NmimCgsLysvLXnIl9++nduzYtZEqagSN8qEMNVraaTSa7d99df3Py0+fFoaHi4cPHdOlSw9CyJsLplkJrTZ8soWec8W7C6XS8q+27MjMfHz01/13Em4WFuYH+LccMGDY0CGjnlntincXEkLWffQ59fTUqWPrN3zw269/iEQimUz2y/6fbty8lpX12NnJpVu36KlTZguFwoWLZyQl3SGE/P77b//d+lNwq5B79+7+sHNbevo9ewfHrl1eeW3yDGtr67o/Tm0rp/aAOBxOXGz/9Rs+qKpShIVFzJqxgAqkOpai3Em4uWTp7M3/2R4eHklNefTowRszx6/76PPOnbsfOPjzqVPHcnKz/f1adOjQZeqU2Vwu98DBPV99/dnZ0zcIIZWyyu93bP3z+uWycknr4LC4uP4DBwxrrL9gM2KkjW3P3p0/7Nx24rfL1NOiosJx4wetXbOpe/fo2v6y3+/YSnVA9YrtMGf2otGjJkgkpV99/VnKvaTq6uqOHbtOnjjd19e//h+tjjqHjYib8vosqbT8h53brKysOnboOm/uUmdnF0JIamry5/9Zn5v3JCIiavLE6Vu3/adli6BFC1ekpd+bM/e1r778ITSkDbWSiZOGdesWPWf2IkLIwUN7r1+/lJaWwhcIItu2mzZtrreXDzXb0V8P7Nv3Y0VlRZcuPaZNmTNu/KCV734U27svIaQB3ya2Onnq16O/HsjMfNSiRVDvXvEjR7zK4XC+3f7locN7Dx88a2lpSc22Z+/O7d99deTQOZ1OV/fvQ90bYW1/soTEW4uXzCKETJg4tHv36LVrNjVgI+wV24EQsvHTD7/e+n+/HrlACOHxLA8e2rv1v5/z+fzwcPGK5Wvs7eypmXf++O2p34+VlDx1c/MQR7ZftHCFhYVF3RtbbZsoXcCmzz469tshZ2eXnq/0nv/msn9/qJf/ezVaT+YXmzfsP7B7+LCxu3f9Gt0z9v3Vyy7+cZYQ0iu6z+07N+RyOTVbdXX1rVvX43r3I4R8+dWmmzevLZj/9vp1XwwYMOw/X3xy/c8r9X/Hg4f27P55x9gxkz7+6POZMxdcuHj6h53bCCGff7YtNDQ8Pn7g+bO3gluF5OblLF02p1pZvWXz9x+u/jQj4+GixTM0Gk3DVk4I4fF491Lvnj5zfOvXP5747bKAL6B7TetYitIuqqO7u8eZsyfoKRf/OGNv79CxY9eDB/f8tOu7USPH79l9bPDgkb8dP7xn785nqtqwYXXqvbsLF67Y8d3+0NDw//t8XWpaSv3/x1jDdDa2Ka/PGjd2sru7x/mzt0aPmqDVahctmZmYdHvRwne++3avo4PTnLmv5eXn1v+N6qjT0tJy796dFhYWhw+d/eH7A8kpiTt++C/1Md9ZucjR0em7b/dNmzrny68/Ky4u4nCeczv45OTEzVs2tmkTuWbNp8vfXl1WJvno45XUS2np9/7v83XR0XE//nAwpmfcmrUrCCEWFhaEkIZ9m1jpzNmTn2xYHdwqZPdPR6dPm7v/wO4tX20ihPSKiVcoFDduXKXnvHT5fNcur4hEouf+PtSttj9ZlLgD1R7Y9dORtWs2NWwjPHn8CiHkraWrqKijfprkctkn6ze/tfS9lJTE77//mpr+/Y6th4/smz1z4f5fTk2bOufCxdO/7N9V98qfu4l+v2Nr27btPtu0dczoiYcO7zt3/vdnPlT9/5fq0DhtO6VSeer3Y+NffX3I4JGEkAH9h6akJO388ZvonrHR0XGbv/z00uVz/foOJoRcvnJBp9PFxPQhhKxatU6hkHt6eFF/sJMnj964ebVL5+71fNMxoydG94z1929BPU1JSbpx8+rMGfOfme3MmROWPMsPV39qb+9ACFm6ZNWrEwZfvnIhJjquwSuvUijeWvqeSCQihMT27rd+wwcKhUIkEtWnpMGDRu7du/PNeW9xuVxCyPkLp/vGD+JyuUl377RuHda37yBCyKCBw6OiOlYpFM9UlXT3zrixkzt26EIImfHGm9HRcQ72jvX872INlUplshtbcnLikydZmz79ul1UR0LI7FkLr1y9eODA7vlvLqvnG9Vdp7e378QJUwkhxMa2Y4euDx6kEUKu/3lZKi2fOWOBh4enh4fnG9PnUTvFdQsLi/h++z4fHz8ej0cI0ajV76xcJK2Q2tvZ//77MScn5ymvz+LxeN269XzwMC01NZlaqmHfJlY6fvxw27ZRCxcsJ4Q4OjpNeW3Whk/XTBw/NTCwlZeXz6XL56nWWGlpSWpq8vvvra//VlSbOv5khrO9/EZIEYmsJ02cRj2+cvXi3eQEqnvp5z0/zJ61qEePGEJITHRcRsbDn3ZtHzF8XB2reu4mGiXu0CeuP/Xg4KE9yckJvXvFv1C19dE4affgQZpKperY4e8+X3Fk+xMnj0orpM7OLuLI9pcun6d+gK5cudC+XScnJ2dCCNHrDx7c8+eNKzk52dRSnp7e9X9TS0vLm7eurf/k/UePH1B7l46OTv+e7d69pJCQNtSXkxDi4eHp5eVzNzmh7u9n3Sv39Qugoo4QYmNjSwiprKwQiUT1KWnggGHbv/vqzz+vdOvWMyPjUV5ezoD+Qwkh4eGR277ZvGHjmrZto7p27Un3KRmKiBDv++UnqbQ8sm27jh27tg4Orf9/F2tkZD4y2Y0tOSXR0tKS+pUhhHA4HHFk+6S7d17g49VZZ7DBX9zW1k4ulxFCMjMf2djYtGwZRE2PEnewtbV77vtwudz8/Nwvv9qUlp5Ct4bLyyT2dvYZmY9CQ8Opn1RCSM9XYn/Y+Q31uGHfJvbR6/Up95ImT3qDnhIV1VGn091NTojuGdsnrv8v+3e9tXQVl8v949I5KyurHt1j6r8V1aaOP5nhbI2wERJCCIkIF9OP7e0cVEolISQnJ1utVhuOJAgODpXJZHl5OXWs6rmb6DPvpVQqX7Ta+mictJPJKqmjJs9ML5OU2tvZx8T02fLlp9XV1Vwu99r1S9Quhk6nW/7OArVa9cb0eWJxB1sb238vXrdt32w+fvzwzJkLOnbo6u7u8e32L2scUCSTVabfT6V6pQ0Le5mVU706DSvJwcGxe7fos+dOduvW8+IfZ4JbhVD7eqNGjheJrK9cvfjJhtU8Hi8mps/MN+a7uLgaLvv2sg+OHt1/7vypfb/8ZGNtM3z42MmT3qB/lcwE9RNvshubWq1+ZmNzcKhv+/u5ddbYP1kpqxSJ/nHkrD7veOXKxZXvLZkwfsrMGQsCA1vduv3nsrfn0Z/Czc2DnpPOtgZ/m9hHrVar1ert3321/buvDKeXlUkIIXGx/X/Y+c2dhJsdO3S5fPn8K6/0pr6k9dyKalPHn8zQS26ENMMfFnrDk0hKCCFCwd/HGq2sRISQqioFqb3z/LmbKLdJfsQa5z2cXVwJIUsWv+vt7Ws4nfrOxMT0+WLzhqvX/uDz+TqdLia6DyHkwcP09PR7n278qn27v04mk8kqXV3c6n4jrU5LPdDr9b8eOzBq5PhBA4fTi9e4iJOzS0SEeMrr/2g429s51Djzi668YUsNHDBs9YfLKyorLl+5MKD/X8NMLCwsBg0cPmjg8KysjDt3buzYuU0ul3289v8MF7SztZs4YeqE8VNSUpIuXT7/40/bHRycRgwf+9za2MTRwclkNzZnZxcrK6uP/vlX41pw6/nRGlanUCBUqVSGU0pLi2ubWaP96xjbseOHIiLE06fNpd+InkcgEGrU6r/XJimhHzfg28RKfD5fJBLF9xnYs2es4XQvTx9CiI+PX2BgqytXLgQHhyYm3V6/7osG/6rQG2HdfzJDL7kR1s3a2oYQUlVdRU9RKOSEECcnF0nZszs99Mb2Qpuo8TRO2vl4+wkEAqqJSk0pK5Po9Xqqu8/ezr59u043blxVKqu7d4umJkql5YQQ+puclZWRlZXRIiDwmTXzLfnl0r8HodLdO2q1uqqqyuV/i6tUqqvX/qixtsCWrX4//Vtk23Z0gywrK8PHx6+Oj1P/lTdsqc6du9vZ2e/duzM7OzMuth818dSpY8HBoS1aBAYEtAwIaFkpq/zt+CHDpaQV0rNnTw7oP1QoFEaYOH6jAAAgAElEQVREiCMixI8e3c/IePjcwljG09PbSBubpSVfqVRqNBpqr/ZJdiY1/QU2tsDgqqoqNzcPuiM6vyCv/sdW61nnM7y9fcvLyySSUqrPNiHxluJ/R3wFfMFf+92EUGOGS0r++pWpqJB6uHvSK7l06ZzhCh8+TKefXrly4e8P+OLfJrYKDAyulFXSG6FarS4oyHNzc6ee9oqJP3bsoL9/Szs7e6pTsZ5bUW0bYd1/smcKe5mN8Lmfmsvl3ruXRA+8TEtLsbWxdXV1ozpdatzY6thEm1LjjMkUiUSvvzZz54/fJCcnqlSqi3+cXbpszuf/WU/PEB0dd/fundu3/6SGDBBCAvxb8ni8vft+rKisePIka/OWjR07dCksKnhmzaGh4enp9zIyHhFCbt3+8/L/vnh8Pt/PL+DEyaN5+blSafmGT9dEhIsrKyuo7mxvb9+0tJQ7CTfLyiSjRk3Q6XRbvtpUXV2dk5P9321fTJ0+NiPzUR0fp+6Vv/xSHA6nf78hBw7+3K1rT7qb6Oy5k+998NbVq39IK6TXr1++dPlceJtIw6V4XN4PO7d9sObtlJQkiaT0999/e/goPSwsoh5/H1axsrIy0sYWFhah1+tPnvqVGvm9e88Oanrdf1kfH7/S0pLLly/k5GS3b9epU6dun376YVFRoVRafvjIL7NmTzp58mg9P1o963xGl849uFzu5i0b5XJ5bl7Ojz9+6+r610+qr6+/rY3t8RNH9Hq9RqNZv+F9+nhJUGDwzVvXExJvaTQaekwd9V7du0VnZ2fu/nmHXq+/eeu64VWNGvBtYqs3ps27cuXC8RNHdDpdcnLimg9XLF46i27BxMT0KSwqOHnyaK9e8dR4tHr+PtS2Edb9J/P1CyCEXLhwOjUtpWEboUAgcHV1u/W/9dc2m52tXZ+4AT/t+u7q1T8qKit+//23Q4f3jho1wcLCoo6NrY5NtA6GH+q5M9dHo52BMG7s5LeWvrd7z47BQ2P+88UnXp4+S5aspF+Nie5T9LRQo9V07xZNTXF393j3nbWpaclDh/V+Z+Wi6dPmDhkyKi0t5bUp/zgLatjQMbG9+82YNaFXbIcTJ45MHD+V6hMghKx692OhQPj6lFETJw9r367T9OnzhALh8JFxBYX5gweO4HA4by2b+zjjoZ2t3fZv91oJrWbOnjj59ZGJSbffWroquFVI3R+njpU3ylLdukUrlcr4PgPpKUsWrwzwb/nuqsXDhsdu3PRh927Rixe9a7iItbX1mg82lpQ8fXPBtJGj++7Zt3PWzIXUcAxzY6SNLTSkzexZC7dt+6JXbIc1a1dMmzKnPhtbl849IsLFq95fevbcKerc0OjouDVrVwwbEXfw0J64uP4jRtQ1XM1QPet8hrOzy6KFK5Lu3hk5Ov6TDR+MHz/FykrE41lSwyJWrVqXnn6vd1zHVycMjonu4+npTX2iqVPndO7UbeWqxfH9uhYVFS5/e3VI67DlK+afOXuy5yu9hw8b88PObcNH9jl0eO/06fOoVVE/dg34NrFSRIR429Zdd+8mDB/ZZ+myOXK5bO2Hn1G9DoQQby+f1sGhDx6mx/bqSy9Sn9+HOjbCOv5k3l4+/foO/n7H1m++2dzgjXDC+Kl3Em6uem+JYUflv82ds6R7t+gPP3pn5Kj4XT9/P/7VKeNffb3uja2OTbQOz3yol8ehqnnGnyckajWJjH6B8ULwQvbs3Xn06P6ffjxc24AXY3h8t/JptiJ+onuTvWN9pF6vyHlU3W3w8/f1oDZ5+bm2tnZ2tnbUL+OgIdFTX589cuSrDVubRqPJysoICgqmnlJnDX/z3930lJdRnFt96/eSMYtqGHLMoILM6stHS/q9blpVsUnjbqJ1SLwgEQhJp741hJd5DeczBYmJt/MLcn/Yue2D9zc0ZdQBW0ml5XPmvhYUGDxt2lxHR6ft27+04FjQvbgNkJySuHjJrGFDR48dM1kiKfli84Y2bdoGBrZq1KrBjDT6Jtow5pt2K95dmFLLbRYGDBg2e9ZCI73vsuXzuFzutKlzOnfqZqS3AFNj1I3N3t5h/cf/+ebbLe+9v1SlVIaGhn+5ZQd1RbGGiRJ3WLL43RMnj06dPsbGxrZD+y6zZi187sVZwMTt/nnHzz/vqPEl/4CWW774znhv3eibaMOYb09maWmJSq2q8SWRlcjwHCPWQE8mU8xwY6sNejKZUimrrO2kBR6XV59hI80CejJr0PR7FmC2sLEB42xtbG1tbJmugkk4bgQAAOyHtAMAAPZD2gEAAPsh7QAAgP2QdgAAwH5IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7FfztVSE1hb6um7lBs0ShxBre5O7eg7fimspwF6XudDriIPrc2710vR4lhyRncl9NaABuDwLoajma7rW/Cvj4MYvyGTg3rJgVE9zqu2dTe4r7ezJz3uIfStzUZJfbWXDZbqKZ7n6CDKTZUxXAY2gMFPu6M6v8aWa0863lUhVrdVqarhgNDRf0hJVizAbpqt4lqObpZ2TZWVZrbdLBjaRFCpbhlszXUUNQjvZ5T/GLn7zplHrNWq9d5BVja/WnHYWXNJzuOvZ3XXdpxual/P7CiNfsbd2MLndakJIrzFuf+wv0GmZrgOM7Npvxa7e/Np+jJgVO87t2rGnsnLsdTVjZ3fn9xzhUtttQ2u+4w/laY7y8Nd5kTFODi58obUp/krCc6lUOkm+MiO5snM/J9Pcp6ZUlml+/CirY19Xa3uejaOlXod+BfbQ6UhJfnVpbrWrD799rCPT5dRKrdTv3pAd1sXRyoZr58rXa7ERNg9VMm1FqTrhXMmIN31cvQW1zVZX2hFClFW6O+fLinOVigrW7vKUlkocHR0tLNh5s0o7J0s7Z8s2Xe0d3UxuaMC/3fy9rOhJtapap6pmf0OvvLzcxsaGxzO5I6mNzsGNb2XNbRlh4xtsiq26ZyReKC/IqtZpSWVZzbckbL4kkjJ7e3sul22Dwqxsee6+gvaxjnWPd3tO2pmDXr16HT161NbWrO/8BE1v8uTJy5cvDwsLY7oQMBdDhgzZunWrl5cX04Uwg20hDwAA8G9IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7Ie0AwAA9kPaAQAA+yHtAACA/ZB2AADAfkg7AABgP6QdAACwH9IOAADYD2kHAADsh7QDAAD2Q9oBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAf0g4AANgPaQcAAOyHtAMAAPZD2hG9Xs90CQAARqfVapkugUk8pgtg3ogRI/r16ycWiyMjI8VisVgs5vP5TBcF7Ofj42Nhgd1NMK7U1NSEhITExMTExMSOHTs6OTkxXRFjOGjZEEKUSmVSUlLi/wQFBVGxFxkZ6ezszHR1wE6TJ09evnx5WFgY04UAq2g0moSEhISEhKSkpISEhKCgoKioKLFYHBUV5eDgwHR1TELa1SA1NTUxMZHKP2trazr5/P39mS4N2ANpB41FKpUmJiZSbbj09PSoqCgq4dBTZQhp9xxPnjyhk6+iokL8P23atGG6NGjekHbwMgoKCuguytLSUqr1JhaLw8PDmS7NROG43XP4+fn5+fkNGTKEEFJWVkZtWxs3bkxPT6eTLyoqSiAQMF0pALDc48eP6V5KDodDxdu4ceNatmzJdGnNANp2DaTRaBINBAQE0OHn4uLCdHXQDKBtB/Vx9+5dupfS3d2dbsO5u7szXVozg7RrHOnp6XTyCYVCenhnixYtmC4NTBTSDmqkVCqpBhz1e9KmTRv6IJytrS3T1TVjSLvGl5eXRyefRCKhRrhERUVFREQwXRqYEKQd0CQSCdWAS0hIyMrKohtwYrGYy+UyXR1L4Lhd4/P29vb29h44cCA1Vooa4fLZZ5+lpqbSwzvFYrFIJGK6UgBgTG5uLtWAS0hIkMlkVLwNHDgwJCSE6dLYCW27pqPVaunhnYmJiT4+PnT4oQveDKFtZ4bu379PH4QTCoX0qQJ+fn5Ml8Z+SDvGPHjwgA4/CwsLqu8iMjIyMDCQ6dKgKSDtzIFer6fjLSEhwc/Pj/qmR0VF4coVTQxpZxIKCgroQ31Pnz6lh3dGRkYyXRoYC9KOreRyOZ1wSUlJ9EG4qKgoKysrpqszXzhuZxI8PT09PT379+9PCKmsrKRib/PmzUlJSfTwTrFYbGNjw3SlAFCDp0+fUl/bhISEgoICamDam2++iR1W04G2nakzPKvPw8ODTj4PDw+mS4OXgrZdc5eVlUW34dRqNX2tiVatWjFdGtQAbTtTR32FqMfUlRQuX768ZcsWQgjd7MO3C6Bp3Lt3j7rackJCgoODg1gs7tSp04wZM7y9vZkuDZ4DbbvmqqioiG7z5efnG96xCPeRaRbQtmsWqFsK0L2UrVq1ottwZn5LgWYHaccGcrnc8I5F4eHh1PBOsVhsZ2fHdHVQM6SdyaJuKUDFG3VLAXqkCW4p0Hwh7ViIurAexcXFhR7eic4WUxAfH8/lcjkcjkQisbW15fF4HA7H3t7+559/Zro0s0bdUoDqpaRuKUAlHG4pwBpIO5bLyMigz+pTqVT0IJfWrVszXZqZ6tevX0lJieEULpc7ffr0N954g7mizBR1IJzaL6RvKSAWi3FLAVZC2pmR4uJi6oudlJSUlZVFf7dxLb6mtHr16iNHjhgeWw0KCtq6dSsOAjUNuucjISGBuqUA1YbD9YxYD2lnpqqrq+m92qSkpJCQEDr58LNrVNnZ2bNnz3769Cn1lMvlzpgxY9q0aUzXxVo13lKAOh8OtxQwK0g7IISQlJQU+lCfg4MDPbzT19eX6dJY6MMPPzxy5Aj1ODAwcNu2bfb29kwXxSr0LQUSExMzMzNxSwFA2kENsrOz6eSrqqqiky80NJTp0lgiKytr/vz5+fn5lpaW06ZNmz59OtMVsQF9S4HExMTKyko63rDdAgVpB3UpLS2lky8jI8PwrD4MxX4Z69atO3DggL+///bt29F13GA13lIgMjLS39+f6dLA5CDtoL6USqXhWX1BQUH0oT4nJ6cmK0OvJ9VybWWZpsne0RgKCgo++uijXr16jRw5kulaXgqPz3Fyb9L9HsODcL6+vnQvpYuLS1OWAc0O0g4aKDU1lRrhkpCQYGNjQ5/VZ9Td6vu3Ku9elkpL1c4eguoqrfHeCOrJ2o6X+1Ae1sk+ZrSrkd6itlsK4JbI8EKQdtAInjx5Qp/VV1FRQbf52rRp04jvkny1IjtV0WWgm0CES6OZEJ1Wn/tQkXRRMnaxD5fHaZR1FhcX0/eEoy6MR/dSNsr6wQwh7aCRlZWV0Sc2pKen0+czicVigUDQ4NWmXJVm36/qOQJ3fjBRJbnK68eLXn2r4ffgzs7OpnspVSoVfb0uXPQcGgXSDoxIo9HQZ/ImJSUFBATQzb46jrL06NEjNDR0y5YtdDpqVPoj2/LjJ+HKZyYt+VKZnTM3vOvfl2ZduXLluXPnrl69WtsiVH+44S0FqJDDVe6g0SHtoOmkp6fTg1yEQiE9vLNFixaGs7Vr144Q0qJFi7Vr11LDxwuzqy8eKBkwzYe52uH5HiVWluQp+ox3J4TIZLIFCxbcvXtXr9f7+PgcPnyYmofaAaJ7KYOCgug2HMamglEh7YAZeXl5dPJJJBJqhEtUVFRERES7du2oC2u5ubktWLCgb9++D+7I8jOV7eOcma4a6lJaoEz/s7zfa+73799fuXLl48ePqb+jSCRau3Yt1YCjOrepg3A4jwWaEtIOmCeVSqkRLgkJCXfv3uVw/h7p4ODgMGrUqOj247PTqrsPdWO0THiO4tzqW7+XOEWkf/3119nZ2fR0nU7Xq1cv3FIAmIW0A9MSExMjk8kMp1haWsZ3m9I1chjSzsQV51af2ffo8M1l9FVAKXq9/vbt28zVBUAIIRjJDaalsrKSeqDT6XQ6nZWVlbu7e3FxMdN1Qb2o1WqBQODo6GhhYaHT6bRaLSGEw+GMGDGC6dLA3PGYLgDgH7Rarb29va2trYuLS1hYWNu2bYODg5WlLtlp1UyXBs/n6up66ONDOTk56enpN27cSElJkUqlUqn0mdYeQNND2oFpmTp1KpVwXl5e9MS00gpGi4IX4+vr6+vr26dPH0JIeXn5/fv3O3fuzHRRYO6QdmBa5s+fz3QJ0JgcHBwQdWAKcNwOAADYD2kHAADsh7QDAAD2Q9oBAAD7Ie0AAID9kHYAAMB+SDtgJ4VC8fH69wYO7rns7XkHDu6J7dPpZdY2bETczh+/bbzqnu+D1W8vfWtOY61t6PDYJq4fwNQg7YCdklMST58+PuX1WTPemB8WGj5p4nSmK2pqw0f2yS/Iox6PHTOpbUQU0xUBMAlnlwM7KRRyQkhcbH8HB0dCSGioeV16v7CwoLy8jH46/tXXGS0HgHlo2wEL7d3345oPV1Dtm2d6MlevWb7mwxVXr/4xZFjvPn27LFj0RlpaCvVSZubj/3zxyWtTRvXt323mrIlHju5/0fc9eerXOfNe7z+wx5x5r+8/sJu6wci3278cOLinWq2mZ9uzd2efvl0UCoVMJvt+x9bZc1/rP7DHxEnDvvr6/6qrn70caFr6vV6xHdLS79FTqDmpxwcP7V329rzBQ2JGju675sMVefm5hJCExFuvThhMCJkwcejK95Y805P55EnW4iWzBg2JHjo8dsGiNxISb1HTDx3eN2JU/JMnWVOmjekV22HaG+NOnvr1Rf8HAEwW0g5YaOyYSe+tWkcIOXTg9IZPthi+xOPx7qXePX3m+Navfzzx22UBX7Duk/epl778atPNm9cWzH97/bovBgwY9p8vPrn+55X6v+mZsyc/2bA6uFXI7p+OTp82d/+B3Vu+2kQI6RUTr1Aobty4Ss956fL5rl1eEYlEBw/t2f3zjrFjJn380eczZy64cPH0Dzu31f8dk5MTN2/Z2KZN5Jo1ny5/e3VZmeSjj1cSQqLEHdZ99DkhZNdPR9au2WS4SFmZZN6bU9zcPLb9d/eXm793dHD6cO07CoWCurOSTFb5xeYNby1Zde7MzeiecRs2rikqKqx/PQCmDGkHZqdKoXhr6Xtent48Hi+2d7+cnGzq537VqnUbN37VLqpjlLjD0CGjWgeH3rh5tR7r+8vx44fbto1auGC5o6NTu6iOU16bdfjwvrIySWBgKy8vn0uXz1OzlZaWpKYm9+7dlxAyZvTEb7f9HBMdFyXu8EqPXr1i4l/oHcPCIr7fvm/C+ClR4g4dO3QZM3piWlqKtEJaxyK/7N/FFwiWLlnp5ent4+P31tL3qqoUR47+Qr2qVqtfmzwjLCyCw+H0jR+k1+sfPbpf/3oATBmO24HZ8fULEIlE1GMbG1tCSGVlhUgkInr9wYN7/rxxJSfnr/tue3p613OdOp0u5V7S5Elv0FOiojrqdLq7yQnRPWP7xPX/Zf+ut5au4nK5f1w6Z2Vl1aN7DNWcunnr2vpP3n/0+IFGoyGEODo61f+DcLnc/PzcL7/alJaeIpfLqYnlZRJ7O/vaFsnIfNSqVQiP99cX39ra2tfH/8GDNHqGkJA21ANbWztCiExWWf96AEwZ2nZgdiwsatjsdTrd8ncWJCTefGP6vKNHzp8/eys8PLL+61SpVGq1evt3X/WK7UD9G/vqQKrnkBoso1Ao7iTcJIRcvnz+lVd6U3mz7ZvNP/ywbeDA4T/tPHz+7K0J46e80Ae5cuXiu6sWt24d9vln35w7c/OZPtsaSUpLhAKh4RShlZWiSkE/5XA4L1QDQHOBth0AIYQ8eJienn7v041ftW/313gWmazS1cWtnosLhUKRSBTfZ2DPnrGG0708fQghPj5+gYGtrly5EBwcmph0e/26Lwgher3+12MHRo0cP2jgcPod6/NeGq2GenDs+KGICPH0aXPrv7jI2rpa+Y+BMFUKhY+3Xz0/JkDzhbQDIIQQqbScEELHW1ZWRlZWRouAwPqvITAwuFJWGSXuQD1Vq9UFBXlubu7U014x8ceOHfT3b2lnZ98uqiM1Q1VVlcv/3lGlUl299se/VyvgCwghVf9rfslkspKSYupxRYXUw92TnvPSpXPPLbJ1cNip34+p1WpLS0tCSEVlRfaTzPj4gfX/mADNFHoyAQghJMC/JY/H27vvx4rKiidPsjZv2dixQ5fCooL6r+GNafOuXLlw/MQRnU6XnJy45sMVi5fOUqlU1KsxMX0KiwpOnjzaq1c8l8slhPD5fD+/gBMnj+bl50ql5Rs+XRMRLq6srKCPwFF8ff1tbWyPnzii1+s1Gs36De9TR9QIIUGBwTdvXU9IvKXRaH7Zv4uaSNXs6xdACLlw4XTq/86voAwePFIul2367KOiosKsrIx1698TCoQD+g976f8/AFOHtAMghBB3d49331mbmpY8dFjvd1Yumj5t7pAho9LSUl6bMqqea4iIEG/buuvu3YThI/ssXTZHLpet/fAzgUBAvert5dM6OPTBw/TYXn3pRVa9+7FQIHx9yqiJk4e1b9dp+vR5QoFw+Mi4gsJ8eh5LS8tVq9alp9/rHdfx1QmDY6L7eHp6U2fyTZ06p3OnbitXLY7v17WoqHD526tDWoctXzH/zNmT3l4+/foO/n7H1m++2WxYpI+37/vvrc/MfDRu/KCFi2cQQv7z+bfW1taN9L8IYLo41NcGwJSl3azITqvuPrS+R9GAEcW51bd+LxmzyIfpQgBqgLYdAACwH0apANTXincXpiQn1vjSgAHDZs9a2OQVAUB9Ie0A6mvp4pUqtarGl0RWoiYvBwBeANIOoL6cnV2YLgEAGgjH7QAAgP2QdgAAwH5IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7Ie0AwAA9kPaAQAA+yHtAACA/ZB20AzwLC2sbLCtmjoOh+Pgxme6CoCa4RcEmgEnd37uAwXTVcBzlORVC4QcpqsAqBnSDpoBZ0++tR1Po8S9GE2aTKrxDcbVscFEIe2geejU1/HEjhymq4BaJV2QqBTqlhG4DTqYKNy7HJqN0gLV0W35nfu72jnzbRx5BFuuCdBrSXFedUFWFdFpo0e6Ml0OQK2QdtCcyMo1N09Lch9V6TREUaFhupyXotfrOZxmf5TL1VfAs+QEt7ML62zLdC0AdUHaQfOkJ6SZJ8XkyZOXL18eFhbGdCEAZgHH7aB5auZRBwBNDGkHAADsh7QDAAD2Q9oBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAf0g4AANgPaQcAAOyHtAMAAPZD2gEAAPsh7QAAgP2QdgAAwH5IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7Ie0AwAA9kPaAQAA+yHtAACA/ZB2AADAfkg7AABgP6QdADMCAgIsLPAFBGgi+LIBMCMrK0un0zFdBYC5QNoBAAD7Ie0AAID9kHYAAMB+SDsAAGA/pB0AALAf0g4AANgPaQcAAOyHtAMAAPZD2gEAAPsh7QAAgP2QdgAAwH5IOwAAYD+kHQAAsB/SDgAA2A9pBwAA7MfR6/VM1wBgRkaMGMHlcnk8Xk5OjpOTk0Ag4PF4tra227ZtY7o0ADbjMV0AgHlRqVSFhYXU4/z8fEKIXq8fO3Ys03UBsBx6MgGaVNu2bbVareEUX1/f8ePHM1cRgFlA2gE0qUmTJnl7extO6d69u4+PD3MVAZgFpB1AkwoNDW3bti391NvbGw07gCaAtANoahMnTvT09KQev/LKK8809QDAGJB2AE0tLCwsMjKSatiNGTOG6XIAzALGZALUm46oNY1zxs7YMRNu/HmnR/cYTw9ftaoR1skhHB6/MSoDYCmcbwdQK7lUm5EiK8xSFWZXVck1FhYctUrHdFE1c/QQlhVUC6259q4CN29+YKS1Z4CQ6aIATAjSDqAGWffkd69WFmZV2bmKbNxseJYWPD6Pxzfpnn+dVq9RajVqnbysSiGRV8vVbXs4dB3gxHRdACYBaQfwD4VZygsHizUaC9cAR4FtM+4c1Kp15fmVhQ8lXQa6tO/twHQ5AAxD2gH87cpvZbmPVLZuNiIHlnQD6vXk6SOJVqkcs8iHh8P0YMaQdgB/OfljUUU5xy3ImelCGp9Cqsy+UzDl/QChNZfpWgCYgbQDIISQPw5LiouIs58904UYi06rL0wrHD7b08oGgQfmyKSPugM0jQsHiktYHXWEEAsuxzPM4/vVWUwXAsAMpB2Yu3vXK4pytU6sjjoKx4LTor3n7o05TBcCwACkHZi1aoXu2m+l7sGuTBfSRKzsBXwbq1tnypguBKCpIe3ArF06XOLs78h0FU3KJcDx+vFSHK8Hc4O0A/MlLVE/ua9w9LZlupCm5tna6dLhEqarAGhSSDswX0mXyh287JiuolaJyWeWruoskzd+r6Ojt13KVWmjrxbAlCHtwHw9TpbbulgzXQUDLLgcW2dhzoMqpgsBaDpIOzBTZUUqvZ7DF5np9UVEjqJHSTKmqwBoOmb6VQcoyFLauoqMt/6bd45du3mooOiRp3uQOCLula7jOBwOIeTHve8QwmkX2W/vwTVKpcLfN2Jg33n+vuHUUsdObr6VdFzAF0W17evm4me88mycrMqeSoy3fgBTg7YdmKlKiUqv5xhp5XeSTu099KGPV+t3Fh/q32f2H1f3HDn+f9RLFha87Jzk24knFsza8fF7F3mW/D0H11AvXb1x4OqN/SMGvrVg5vfOjl6nz283UnmEEC7forRAabz1A5gapB2YKZlUy+Mbq2/jxu0jLf2jRgxeZmvj1Kplh76xM678+Uul7K+2lFKpGDt8pbOTN5fLa9e2b3FJtlKpIIRcvravbZvYtuG9RSK7ju0GBbXsYKTyCCE8Plep0BKchwBmA2kHZkpPOHwrS2OsWafTZT65G9yqMz2lVcsOer0uMyuReurmGiAQ/NWJKhTaEkIUVRV6vb5EkuPu1oJeyscrxBjl0Vx9RfIKrVHfAsB04LgdmCu9XlWtJqTx7xLDkqwAAAOUSURBVOyj0ai0WvXJM1tPntlqOL1S/lfbjsOpYS+zWinX6bR0ChJC+HyrRq/NUHGuQmSLK0SDuUDagZmyseeWSYzSsuHzhQK+qL14QNs2vQ2nOzt517GUUGBtYcFVq6vpKUqVwhjlUTQqHV9oUVPsArAT0g7MlK2TpT7DWMM0vDyDq6org1q2p55qNOrSsjwHe/c6FuFwOI4OnllPkqO7/zUl7f4VI5VHCNGqtA6uAuOtH8DUYNcOzJS7n1AuMdbp1QP6zE5Ju/jn7aM6nS4zO/Gnfe/+9/u5Go2q7qUiw+OSU88nJp8hhJy7tDM7N8VI5RFC5OXVzp5GOWwJYJqQdmCmXLz4Oo1OXW2UzswW/uJFs3dmZiV+8Em//+54s6paNmXCRkvL57Sl4qKndG4/9PDxTUtXdU67f2VI/4WEECPdb1lRJg9qa2OMNQOYJty7HMzXuX3F5eU8J1/TvVSmsehJytnMeZuCmK4DoOmgbQfmq20Pe7lEznQVDCgvkIV3Zf/dawEMYZQKmC8XL76LB6+iSGbnXnOf3r30Sz8f+KDGl0RWdoqqihpf6tx+6OB+8xuryMzsxO0/LanxJZ1Oy+FYUBcke8YrXcb2jZ1R2zoLHpQMXNOitlcBWAk9mWDWZOWanz/NadW95itSqlTVMnnNF5NUKqsEgprPh+PzRTbWDo1YpKQs/0UXEQpsRKKae2hLs8s9fUi3Qc6NURpAs4G0A3N353x5RprapYUT04U0BZVCU3S/aNI7RrzeNIBpwnE7MHftejlYW+vK883i9jcPr+WMX+bLdBUADEDbDoAQQo7veKrUCBy92Two/0li4ZA33BxccJodmCO07QAIIWTA6256pbwkq5zpQoxCpdDcO5s1ZDqiDswX2nYAf7t4qLQoV2vvaSewZk8qFGeWy0tkk1b4cS2NdT8/ANOHtAP4h8wUxcVDxUIbgUuAE0/YvG8RUJ4vK3hQ2qaLfc/hGIEJ5g5pB1CDtBsVqTdk0hK1tbO1nZs1j8+1FHCJyTeNtGqdVqWTlVXJShUVTxVtujp0H+zEF+KABQDSDqB2pQWqzHvyp7mqggxFlUwrsrfUakz0+2LtwC8rUPAsLRzd+M6e/MAI64A21kwXBWBCkHYA9VVVqVOrdUxXUTMOh4hsuVyeyTc/ARiCtAMAAPZDhz4AALAf0g4AANgPaQcAAOyHtAMAAPZD2gEAAPsh7QAAgP3+H+0U2nCpkPnvAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<langgraph.graph.state.CompiledStateGraph object at 0x00000243DEFF53F0>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10550a25",
+   "metadata": {},
+   "source": [
+    "### Execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "274d3ad8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "essay2 = \"\"\"India and AI Time\n",
+    "\n",
+    "Now world change very fast because new tech call Artificial Intel… something (AI). India also want become big in this AI thing. If work hard, India can go top. But if no careful, India go back.\n",
+    "\n",
+    "India have many good. We have smart student, many engine-ear, and good IT peoples. Big company like TCS, Infosys, Wipro already use AI. Government also do program “AI for All”. It want AI in farm, doctor place, school and transport.\n",
+    "\n",
+    "In farm, AI help farmer know when to put seed, when rain come, how stop bug. In health, AI help doctor see sick early. In school, AI help student learn good. Government office use AI to find bad people and work fast.\n",
+    "\n",
+    "But problem come also. First is many villager no have phone or internet. So AI not help them. Second, many people lose job because AI and machine do work. Poor people get more bad.\n",
+    "\n",
+    "One more big problem is privacy. AI need big big data. Who take care? India still make data rule. If no strong rule, AI do bad.\n",
+    "\n",
+    "India must all people together – govern, school, company and normal people. We teach AI and make sure AI not bad. Also talk to other country and learn from them.\n",
+    "\n",
+    "If India use AI good way, we become strong, help poor and make better life. But if only rich use AI, and poor no get, then big bad thing happen.\n",
+    "\n",
+    "So, in short, AI time in India have many hope and many danger. We must go right road. AI must help all people, not only some. Then India grow big and world say \"good job India\".\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "a84e7069",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "intial_state = {\n",
+    "    'essay': essay2\n",
+    "}\n",
+    "\n",
+    "final_state = workflow.invoke(intial_state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "2404ddb0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'essay': 'India and AI Time\\n\\nNow world change very fast because new tech call Artificial Intel… something (AI). India also want become big in this AI thing. If work hard, India can go top. But if no careful, India go back.\\n\\nIndia have many good. We have smart student, many engine-ear, and good IT peoples. Big company like TCS, Infosys, Wipro already use AI. Government also do program “AI for All”. It want AI in farm, doctor place, school and transport.\\n\\nIn farm, AI help farmer know when to put seed, when rain come, how stop bug. In health, AI help doctor see sick early. In school, AI help student learn good. Government office use AI to find bad people and work fast.\\n\\nBut problem come also. First is many villager no have phone or internet. So AI not help them. Second, many people lose job because AI and machine do work. Poor people get more bad.\\n\\nOne more big problem is privacy. AI need big big data. Who take care? India still make data rule. If no strong rule, AI do bad.\\n\\nIndia must all people together – govern, school, company and normal people. We teach AI and make sure AI not bad. Also talk to other country and learn from them.\\n\\nIf India use AI good way, we become strong, help poor and make better life. But if only rich use AI, and poor no get, then big bad thing happen.\\n\\nSo, in short, AI time in India have many hope and many danger. We must go right road. AI must help all people, not only some. Then India grow big and world say \"good job India\".',\n",
+       " 'language_feedback': 'The essay demonstrates a basic understanding of the topic but suffers from significant grammatical errors, awkward phrasing, and a lack of sophisticated vocabulary. The language is overly simplistic and colloquial, hindering clear communication. For instance, phrases like \"AI thing,\" \"go top,\" \"no careful,\" \"many good,\" \"farm, doctor place, school and transport,\" \"know when to put seed,\" \"see sick early,\" \"learn good,\" \"find bad people and work fast,\" \"many villager no have phone or internet,\" \"lose job because AI and machine do work,\" \"Poor people get more bad,\" \"privacy. AI need big big data. Who take care? India still make data rule. If no strong rule, AI do bad,\" \"all people together – govern, school, company and normal people,\" \"teach AI and make sure AI not bad,\" \"talk to other country and learn from them,\" \"use AI good way,\" \"make better life,\" \"only rich use AI, and poor no get, then big bad thing happen,\" and \"go right road\" are informal and detract from the essay\\'s credibility. While the core ideas are present, the execution in terms of language quality is poor. A score of 3/10 is assigned due to the fundamental issues with grammar, sentence structure, and vocabulary choice.',\n",
+       " 'analysis_feedback': \"The essay touches upon the potential of AI in India, mentioning its strengths like a large pool of tech talent and government initiatives. However, the analysis lacks depth. It identifies key areas like agriculture, healthcare, and education where AI can be applied, but doesn't delve into the specifics of *how* AI would be implemented or the nuanced challenges involved. For instance, while mentioning job losses, it doesn't explore the scale of this issue or potential mitigation strategies. The privacy concern is raised but not elaborated upon in terms of existing data protection measures or specific regulatory needs. The essay presents a very high-level overview without a thorough examination of the complexities and potential pitfalls. The language is also quite simplistic, which, while accessible, doesn't lend itself to a deep analytical tone.\",\n",
+       " 'clarity_feedback': \"The essay demonstrates a basic understanding of AI's potential impact on India, covering both opportunities and challenges. However, the clarity of thought is hampered by simplistic language, repetitive phrasing, and a lack of structured argumentation. For instance, the essay jumps between points without smooth transitions, and the explanation of AI's applications is quite superficial. The conclusion reiterates the main points but doesn't offer a sophisticated synthesis. While the core message about equitable AI development is valid, the expression lacks depth and academic rigor.\",\n",
+       " 'overall_feedback': \"Here's a summarized feedback based on the provided critiques:\\n\\n**Overall Feedback Summary:**\\n\\nThe essay demonstrates a foundational understanding of AI's potential impact on India, identifying both opportunities and challenges. However, the analysis suffers from significant weaknesses in **language, depth of analysis, and clarity of thought**.\\n\\nThe **language** is overly simplistic, colloquial, and riddled with grammatical errors and awkward phrasing, hindering clear communication and reducing credibility. The **depth of analysis** is superficial, presenting a high-level overview without delving into the specifics of AI implementation, nuanced challenges, or detailed mitigation strategies for issues like job displacement and privacy. **Clarity of thought** is further compromised by simplistic language, repetitive points, and a lack of structured argumentation and smooth transitions.\\n\\nWhile the core message about equitable AI development is present, the execution in terms of language quality, analytical rigor, and coherent expression is poor.\",\n",
+       " 'individual_scores': [5, 3, 5],\n",
+       " 'avg_score': 4.333333333333333}"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# display(Markdown(final_state))\n",
+    "# print(final_state)\n",
+    "final_state"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "myenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- Implemented a parallel evaluation chain using LangGraph to analyze essays.
- Takes a single essay as input and evaluates it across multiple dimensions.
- Generates language feedback, analysis feedback, clarity feedback, and overall comments.
- Computes individual scores (0–10) for each category and calculates an average score.
- Designed for modular and scalable evaluation using LLM nodes in parallel.